### PR TITLE
Make LocalisedLine contain line state, not views

### DIFF
--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -85,9 +85,9 @@ namespace Yarn.Unity
 
 #if ADDRESSABLES
         /// <summary>
-        /// Whether the DialogueRunner should wait for the linked 
-        /// Addressable voice over AudioClips to finish loading (true)
-        /// or not (false).
+        /// Whether the DialogueRunner should wait for the linked
+        /// Addressable voice over AudioClips to finish loading (true) or
+        /// not (false).
         /// </summary>
         public bool waitForAddressablesLoaded = true;
 #endif
@@ -147,36 +147,38 @@ namespace Yarn.Unity
         public Dialogue Dialogue => dialogue ?? (dialogue = CreateDialogueInstance());
 
         /// <summary>
-        /// A <see cref="StringUnityEvent"/> that is called when a <see cref="Command"/> 
+        /// A <see cref="StringUnityEvent"/> that is called when a <see
+        /// cref="Command"/> 
         /// is received.
         /// </summary>
         /// <remarks>
-        /// <para>
-        /// Use this method to dispatch a command to other parts of your game.
-        /// This method is only called if the <see cref="Command"/> has not
-        /// been handled by a command handler that has been added to the
+        /// Use this method to dispatch a command to other parts of your
+        /// game. This method is only called if the <see cref="Command"/>
+        /// has not been handled by a command handler that has been added
+        /// to the
         /// <see cref="DialogueRunner"/>, or by a method on a <see
         /// cref="MonoBehaviour"/> in the scene with the attribute <see
-        /// cref="YarnCommandAttribute"/>.
-        /// {{|note|}}
-        /// When a command is delivered in this way, the <see cref="DialogueRunner"/> 
-        /// will not pause execution. If you want a command to make the DialogueRunner 
-        /// pause execution, see <see cref="AddCommandHandler(string, BlockingCommandHandler)"/>.
+        /// cref="YarnCommandAttribute"/>. {{|note|}} When a command is
+        /// delivered in this way, the <see cref="DialogueRunner"/> 
+        /// will not pause execution. If you want a command to make the
+        /// DialogueRunner pause execution, see <see
+        /// cref="AddCommandHandler(string, BlockingCommandHandler)"/>.
         /// {{|/note|}}
-        /// </para>
-        /// <para>
-        /// This method receives the full text of the command, as it appears between
-        /// the `<![CDATA[<<]]>` and `<![CDATA[>>]]>` markers.
-        /// </para>
+        /// 
+        /// This method receives the full text of the command, as it
+        /// appears between the `<![CDATA[<<]]>` and `<![CDATA[>>]]>`
+        /// markers.
         /// </remarks>
         /// <seealso cref="AddCommandHandler(string, CommandHandler)"/>
-        /// <seealso cref="AddCommandHandler(string, BlockingCommandHandler)"/>
+        /// <seealso cref="AddCommandHandler(string,
+        /// BlockingCommandHandler)"/>
         /// <seealso cref="YarnCommandAttribute"/>
         public StringUnityEvent onCommand;
 
         /// <summary>
         /// Adds a program, and parses and adds the contents of the
-        /// program's string table to the DialogueRunner's combined string table.
+        /// program's string table to the DialogueRunner's combined string
+        /// table.
         /// </summary>
         /// <remarks>This method calls <see
         /// cref="AddDialogueLines(YarnProgram)"/> to load the string table
@@ -269,7 +271,8 @@ namespace Yarn.Unity
         /// Returns `true` when a node named `nodeName` has been loaded.
         /// </summary>
         /// <param name="nodeName">The name of the node.</param>
-        /// <returns>`true` if the node is loaded, `false` otherwise/</returns>
+        /// <returns>`true` if the node is loaded, `false`
+        /// otherwise/</returns>
         public bool NodeExists(string nodeName) => Dialogue.NodeExists(nodeName);
 
         /// <summary>
@@ -282,23 +285,23 @@ namespace Yarn.Unity
         public IEnumerable<string> GetTagsForNode(String nodeName) => Dialogue.GetTagsForNode(nodeName);
 
         /// <summary>
-        /// Adds a command handler. Dialogue will continue running after the command is called.
+        /// Adds a command handler. Dialogue will continue running after
+        /// the command is called.
         /// </summary>
         /// <remarks>
         /// When this command handler has been added, it can be called from
         /// your Yarn scripts like so:
         ///
-        /// <![CDATA[
-        /// ```yarn
+        /// <![CDATA[```yarn
         /// <<commandName param1 param2>>
-        /// ```
-        /// ]]>
+        /// ```]]>
         ///
         /// When this command handler is called, the DialogueRunner will
         /// not stop executing code.
         /// </remarks>
         /// <param name="commandName">The name of the command.</param>
-        /// <param name="handler">The <see cref="CommandHandler"/> that will be invoked when the command is called.</param>
+        /// <param name="handler">The <see cref="CommandHandler"/> that
+        /// will be invoked when the command is called.</param>
         public void AddCommandHandler(string commandName, CommandHandler handler)
         {
             if (commandHandlers.ContainsKey(commandName) || blockingCommandHandlers.ContainsKey(commandName)) {
@@ -431,7 +434,8 @@ namespace Yarn.Unity
         /// Remove a registered function.
         /// </summary>
         /// <remarks>
-        /// After a function has been removed, it cannot be called from Yarn scripts.
+        /// After a function has been removed, it cannot be called from
+        /// Yarn scripts.
         /// </remarks>
         /// <param name="name">The name of the function to remove.</param>
         /// <seealso cref="AddFunction(string, int, Function)"/>
@@ -469,9 +473,11 @@ namespace Yarn.Unity
         /// </remarks>
         /// <param name="parameters">The list of parameters that this
         /// command was invoked with.</param>
-        /// <param name="onComplete">The method to call when the DialogueRunner should continue executing code.</param>
+        /// <param name="onComplete">The method to call when the
+        /// DialogueRunner should continue executing code.</param>
         /// <seealso cref="AddCommandHandler(string, CommandHandler)"/>
-        /// <seealso cref="AddCommandHandler(string, BlockingCommandHandler)"/>
+        /// <seealso cref="AddCommandHandler(string,
+        /// BlockingCommandHandler)"/>
         public delegate void BlockingCommandHandler(string[] parameters, Action onComplete);
 
         /// Maps the names of commands to action delegates.
@@ -479,11 +485,14 @@ namespace Yarn.Unity
         Dictionary<string, BlockingCommandHandler> blockingCommandHandlers = new Dictionary<string, BlockingCommandHandler>();
 
         /// <summary>
-        /// Collection of dialogue lines linked with their corresponding Yarn linetags.
+        /// Collection of dialogue lines linked with their corresponding
+        /// Yarn linetags.
         /// </summary>
         Dictionary<string, string> localizedText = new Dictionary<string, string>();
+        
         /// <summary>
-        /// Collection of voice over AudioClips linked with their corresponding Yarn linetags.
+        /// Collection of voice over AudioClips linked with their
+        /// corresponding Yarn linetags.
         /// </summary>
         Dictionary<string, AudioClip> localizedAudio = new Dictionary<string, AudioClip>();
 
@@ -498,17 +507,20 @@ namespace Yarn.Unity
         bool wasCompleteCalled = false;
 
         /// <summary>
-        /// A flag caching if a View has communicated the user's intent to proceed to the next line
+        /// A flag caching if a View has communicated the user's intent to
+        /// proceed to the next line
         /// </summary>
         bool userIntendedNextLine = false;
 
         /// <summary>
-        /// List of Addressable voice over AudioClips being currently loaded.
+        /// List of Addressable voice over AudioClips being currently
+        /// loaded.
         /// </summary>
         private List<Task> addressableVoiceOverLoadingTasks = new List<Task>();
 
         /// <summary>
-        /// Instance of coroutine checking whether all Addressable loading tasks finished.
+        /// Instance of coroutine checking whether all Addressable loading
+        /// tasks finished.
         /// </summary>
         private Coroutine WaitForAddressablesLoadedCoroutine;
 
@@ -601,16 +613,18 @@ namespace Yarn.Unity
         /// Link a voice over AudioClip with a Yarn linetag.
         /// </summary>
         /// <param name="linetag">The linetag of the line.</param>
-        /// <param name="voiceOver">The voice over AudioClip of the line.</param>
+        /// <param name="voiceOver">The voice over AudioClip of the
+        /// line.</param>
         private void GetVoiceOversCallback(string linetag, AudioClip voiceOver) {
             localizedAudio[linetag] = voiceOver;
         }
 
         /// <summary>
-        /// Check if all Addressable load tasks are finished and invoke the given
-        /// action.
+        /// Check if all Addressable load tasks are finished and invoke the
+        /// given action.
         /// </summary>
-        /// <param name="onAddressablesLoaded">Action invoked after all Addressables are loaded.</param>
+        /// <param name="onAddressablesLoaded">Action invoked after all
+        /// Addressables are loaded.</param>
         /// <returns></returns>
         private IEnumerator CheckAddressablesLoaded(Action onAddressablesLoaded) {
             while (waitForAddressablesLoaded && addressableVoiceOverLoadingTasks.Count > 0) {
@@ -724,21 +738,21 @@ namespace Yarn.Unity
                 bool wasValidCommand;
                 Dialogue.HandlerExecutionType executionType;
 
-                // Try looking in the command handlers first, which is a lot
-                // cheaper than crawling the game object hierarchy.
+                // Try looking in the command handlers first, which is a
+                // lot cheaper than crawling the game object hierarchy.
 
-                // Set a flag that we can use to tell if the dispatched command
-                // immediately called _continue
+                // Set a flag that we can use to tell if the dispatched
+                // command immediately called _continue
                 wasCompleteCalled = false;
 
                 (wasValidCommand, executionType) = DispatchCommandToRegisteredHandlers(command, () => ContinueDialogue());
 
                 if (wasValidCommand) {
 
-                    // This was a valid command. It returned either continue,
-                    // or pause; if it returned pause, there's a chance that
-                    // the command handler immediately called _continue, in
-                    // which case we should not pause.
+                    // This was a valid command. It returned either
+                    // continue, or pause; if it returned pause, there's a
+                    // chance that the command handler immediately called
+                    // _continue, in which case we should not pause.
                     if (wasCompleteCalled) {
                         return Dialogue.HandlerExecutionType.ContinueExecution;
                     }
@@ -749,20 +763,21 @@ namespace Yarn.Unity
                     }
                 }
 
-                // We didn't find it in the comand handlers. Try looking in the game objects.
+                // We didn't find it in the comand handlers. Try looking in
+                // the game objects.
                 (wasValidCommand, executionType) = DispatchCommandToGameObject(command);
 
                 if (wasValidCommand) {
                     // We found an object and method to invoke as a Yarn
-                    // command. It may or may not have been a coroutine; if it
-                    // was a coroutine, executionType will be
+                    // command. It may or may not have been a coroutine; if
+                    // it was a coroutine, executionType will be
                     // HandlerExecutionType.Pause, and we'll wait for it to
                     // complete before resuming execution.
                     return executionType;
                 }
 
-                // We didn't find a method in our C# code to invoke. Try invoking on the 
-                // publicly exposed UnityEvent.
+                // We didn't find a method in our C# code to invoke. Try
+                // invoking on the publicly exposed UnityEvent.
                 onCommand?.Invoke(command.Text);
                 return Dialogue.HandlerExecutionType.ContinueExecution;
             }
@@ -770,7 +785,8 @@ namespace Yarn.Unity
             /// Forward the line to the dialogue UI.
             Dialogue.HandlerExecutionType HandleLine(Line line)
             {
-                // Update lines to current state before sending them to the view classes
+                // Update lines to current state before sending them to the
+                // view classes
                 var substitutions = GetInlineExpressions(line);
                 var text = localizedText.ContainsKey(line.ID) ? localizedText[line.ID] : string.Empty;
                 var audio = localizedAudio.ContainsKey(line.ID) ? localizedAudio[line.ID] : null;
@@ -781,7 +797,8 @@ namespace Yarn.Unity
                     Substitutions = substitutions
                 };
 
-                // First register current dialogue views for line complete calls
+                // First register current dialogue views for line complete
+                // calls
                 foreach (var dialogueView in dialogueViews) {
                     lineCurrentlyRunOnDialogueViews.Add(dialogueView);
                 }
@@ -792,7 +809,8 @@ namespace Yarn.Unity
                 return Dialogue.HandlerExecutionType.PauseExecution;
             }
 
-            /// Indicates to the DialogueRunner that the user has selected an option
+            /// Indicates to the DialogueRunner that the user has selected
+            /// an option
             void SelectedOption(int obj)
             {
                 Dialogue.SetSelectedOption(obj);
@@ -815,8 +833,8 @@ namespace Yarn.Unity
                 if (commandHandlers.ContainsKey(firstWord) == false &&
                     blockingCommandHandlers.ContainsKey(firstWord) == false) {
 
-                    // We don't have a registered handler for this command, but
-                    // some other part of the game might.
+                    // We don't have a registered handler for this command,
+                    // but some other part of the game might.
                     return (false, Dialogue.HandlerExecutionType.ContinueExecution);
                 }
 
@@ -848,13 +866,14 @@ namespace Yarn.Unity
                 }
             }
 
-            /// commands that can be automatically dispatched look like this:
-            /// COMMANDNAME OBJECTNAME <param> <param> <param> ...
+            /// commands that can be automatically dispatched look like
+            /// this: COMMANDNAME OBJECTNAME <param> <param> <param> ...
             /** We can dispatch this command if:
              * 1. it has at least 2 words
              * 2. the second word is the name of an object
              * 3. that object has components that have methods with the
-             *    YarnCommand attribute that have the correct commandString set
+             *    YarnCommand attribute that have the correct commandString
+             *    set
              */
             (bool methodFound, Dialogue.HandlerExecutionType executionType) DispatchCommandToGameObject(Command command)
             {
@@ -902,8 +921,8 @@ namespace Yarn.Unity
                         // Find the YarnCommand attributes on this method
                         var attributes = (YarnCommandAttribute[])method.GetCustomAttributes(typeof(YarnCommandAttribute), true);
 
-                        // Find the YarnCommand whose commandString is equal to
-                        // the command name
+                        // Find the YarnCommand whose commandString is
+                        // equal to the command name
                         foreach (var attribute in attributes) {
                             if (attribute.CommandString == commandName) {
 
@@ -931,7 +950,8 @@ namespace Yarn.Unity
                                     paramsMatch = true;
 
                                 }
-                                // Otherwise, verify that this method has the right number of parameters
+                                // Otherwise, verify that this method has
+                                // the right number of parameters
                                 else if (methodParameters.Length == parameters.Count) {
                                     paramsMatch = true;
                                     foreach (var paramInfo in methodParameters) {
@@ -944,9 +964,9 @@ namespace Yarn.Unity
                                     if (paramsMatch) {
                                         // Cool, we can send the command!
 
-                                        // If this is a coroutine, start it,
-                                        // and set a flag so that we know to
-                                        // wait for it to finish
+                                        // If this is a coroutine, start
+                                        // it, and set a flag so that we
+                                        // know to wait for it to finish
                                         if (method.ReturnType == typeof(IEnumerator)) {
                                             StartCoroutine(DoYarnCommand(component, method, parameters.ToArray()));
                                             startedCoroutine = true;
@@ -959,8 +979,8 @@ namespace Yarn.Unity
                                 }
                                 //parameters are invalid, but name matches.
                                 if (!paramsMatch) {
-                                    //save this error in case a matching
-                                    //command is never found.
+                                    // save this error in case a matching
+                                    // command is never found.
                                     errorValues.Add(new string[] { method.Name, commandName, methodParameters.Length.ToString(), parameters.Count.ToString() });
                                 }
                             }
@@ -968,15 +988,15 @@ namespace Yarn.Unity
                     }
                 }
 
-                // Warn if we found multiple things that could respond to this
-                // command.
+                // Warn if we found multiple things that could respond to
+                // this command.
                 if (numberOfMethodsFound > 1) {
                     Debug.LogWarningFormat(sceneObject, "The command \"{0}\" found {1} targets. " +
                         "You should only have one - check your scripts.", command, numberOfMethodsFound);
                 }
                 else if (numberOfMethodsFound == 0) {
-                    //list all of the near-miss methods only if a proper match
-                    //is not found, but correctly-named methods are.
+                    // list all of the near-miss methods only if a proper
+                    // match is not found, but correctly-named methods are.
                     foreach (string[] errorVal in errorValues) {
                         Debug.LogErrorFormat(sceneObject, "Method \"{0}\" wants to respond to Yarn command \"{1}\", but it has a different number of parameters ({2}) to those provided ({3}), or is not a string array!", errorVal[0], errorVal[1], errorVal[2], errorVal[3]);
                     }
@@ -1038,9 +1058,10 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Called by a <see cref="DialogueViewBase"/> derived class from <see cref="dialogueViews"/>
-        /// to inform the <see cref="DialogueRunner"/> that the user intents to proceed to the next
-        /// line.
+        /// Called by a <see cref="DialogueViewBase"/> derived class from
+        /// <see cref="dialogueViews"/>
+        /// to inform the <see cref="DialogueRunner"/> that the user
+        /// intents to proceed to the next line.
         /// </summary>
         internal void OnViewUserIntentNextLine() {
             userIntendedNextLine = true;
@@ -1062,26 +1083,29 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Called by a <see cref="DialogueViewBase"/> derived class from <see cref="dialogueViews"/>
-        /// to inform the <see cref="DialogueRunner"/> that the user intents to finish the current
-        /// line.
+        /// Called by a <see cref="DialogueViewBase"/> derived class from
+        /// <see cref="dialogueViews"/>
+        /// to inform the <see cref="DialogueRunner"/> that the user
+        /// intents to finish the current line.
         /// </summary>
         internal void OnViewUserIntentFinishLine() {
             FinishLineCurrentlyRunningOnViews();
         }
 
         /// <summary>
-        /// Called by a <see cref="DialogueViewBase"/> derived class from <see cref="dialogueViews"/>
-        /// to inform the <see cref="DialogueRunner"/> that it has finished presenting a line.
+        /// Called by a <see cref="DialogueViewBase"/> derived class from
+        /// <see cref="dialogueViews"/>
+        /// to inform the <see cref="DialogueRunner"/> that it has finished
+        /// presenting a line.
         /// </summary>
         /// <remarks>
-        /// <para>
-        /// Checks and informs all <see cref="dialogueViews"/> if they have all finished a line.
-        /// Also proceeds to the next line if the option 
-        /// <see cref="continueNextLineOnLineFinished"/> is true or if the user
-        /// expressed that intent on one of the <see cref="dialogueViews"/> in which case
-        /// the corresponding view called <see cref="OnViewUserIntentNextLine"/>.
-        /// </para>
+        /// Checks and informs all <see cref="dialogueViews"/> if they have
+        /// all finished a line. Also proceeds to the next line if the
+        /// option 
+        /// <see cref="continueNextLineOnLineFinished"/> is true or if the
+        /// user expressed that intent on one of the <see
+        /// cref="dialogueViews"/> in which case the corresponding view
+        /// called <see cref="OnViewUserIntentNextLine"/>.
         /// </remarks>
         void OnDialogueLineFinished() {
             if (CheckDialogueViewsForCommonLineStatus(DialogueViewBase.DialogueLineStatus.Finished)) {
@@ -1094,8 +1118,9 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Instructs the <see cref="DialogueRunner"/> to check all <see cref="dialogueViews"/> if
-        /// they have all ended the current line and proceeds with the next line in that case.
+        /// Instructs the <see cref="DialogueRunner"/> to check all <see
+        /// cref="dialogueViews"/> if they have all ended the current line
+        /// and proceeds with the next line in that case.
         /// </summary>
         void OnDialogueLineCompleted() {
             if (CheckDialogueViewsForCommonLineStatus(DialogueViewBase.DialogueLineStatus.Ended)) {
@@ -1104,8 +1129,10 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Informs all <see cref="dialogueViews"/> that they have finished a line by calling
-        /// <see cref="DialogueViewBase.OnFinishedLineOnAllViews"/> on them.
+        /// Informs all <see cref="dialogueViews"/> that they have finished
+        /// a line by calling
+        /// <see cref="DialogueViewBase.OnFinishedLineOnAllViews"/> on
+        /// them.
         /// </summary>
         private void LineFinishedOnAllViews() {
             foreach (var dialogueView in dialogueViews) {
@@ -1114,8 +1141,10 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Instructs all <see cref="dialogueViews"/> to end the current line by calling
-        /// <see cref="DialogueViewBase.EndCurrentLine(Action)"/> on all of them.
+        /// Instructs all <see cref="dialogueViews"/> to end the current
+        /// line by calling
+        /// <see cref="DialogueViewBase.EndCurrentLine(Action)"/> on all of
+        /// them.
         /// </summary>
         private void EndLineCurrentlyFinishedOnViews() {
             foreach (var dialogueView in dialogueViews) {
@@ -1126,8 +1155,10 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Instructs all <see cref="dialogueViews"/> to go to the end of the current line by calling
-        /// <see cref="DialogueViewBase.FinishRunningCurrentLine"/> on all of them.
+        /// Instructs all <see cref="dialogueViews"/> to go to the end of
+        /// the current line by calling
+        /// <see cref="DialogueViewBase.FinishRunningCurrentLine"/> on all
+        /// of them.
         /// </summary>
         private void FinishLineCurrentlyRunningOnViews() {
             foreach (var dialogueView in dialogueViews) {
@@ -1138,8 +1169,9 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Check the <see cref="DialogueViewBase.DialogueLineStatus"/> on all <see cref="dialogueViews"/> and get the status with the lowest
-        /// int representation.
+        /// Check the <see cref="DialogueViewBase.DialogueLineStatus"/> on
+        /// all <see cref="dialogueViews"/> and get the status with the
+        /// lowest int representation.
         /// </summary>
         /// <returns></returns>
         DialogueViewBase.DialogueLineStatus GetLowestLineStatus() {
@@ -1153,7 +1185,8 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Return true if all <see cref="dialogueViews"/> have the same <see cref="DialogueViewBase.DialogueLineStatus"/>.
+        /// Return true if all <see cref="dialogueViews"/> have the same
+        /// <see cref="DialogueViewBase.DialogueLineStatus"/>.
         /// </summary>
         /// <param name="commonStatusToCheck"></param>
         /// <returns></returns>
@@ -1184,7 +1217,8 @@ namespace Yarn.Unity
 
     /// <summary>
     /// An attribute that marks a method on a <see cref="MonoBehaviour"/>
-    /// as a [command](<![CDATA[ {{<ref "/docs/unity/working-with-commands">}}]]>).
+    /// as a [command](<![CDATA[ {{<ref
+    /// "/docs/unity/working-with-commands">}}]]>).
     /// </summary>
     /// <remarks>
     /// When a <see cref="DialogueRunner"/> receives a <see
@@ -1204,7 +1238,7 @@ namespace Yarn.Unity
     /// * If the method takes a single <see cref="string"/>[] parameter,
     /// the method is called, and will be passed an array containing all
     /// words in the command after the first two.
-    /// 
+    ///
     /// * If the method takes a number of <see cref="string"/> parameters
     /// equal to the number of words in the command after the first two, it
     /// will be called with those words as parameters.
@@ -1212,15 +1246,13 @@ namespace Yarn.Unity
     /// * Otherwise, it will not be called, and a warning will be issued.
     ///
     /// ### `YarnCommand`s and Coroutines
-    /// 
+    ///
     /// This attribute may be attached to a coroutine. 
-    /// 
-    /// {{|note|}}
-    /// The <see
-    /// cref="DialogueRunner"/> determines if the method is a coroutine if
-    /// the method returns <see cref="IEnumerator"/>.
-    /// {{|/note|}}
-    /// 
+    ///
+    /// {{|note|}} The <see cref="DialogueRunner"/> determines if the
+    /// method is a coroutine if the method returns <see
+    /// cref="IEnumerator"/>. {{|/note|}}
+    ///
     /// If the method is a coroutine, the DialogueRunner will pause
     /// execution until the coroutine ends.
     /// </remarks>

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -541,6 +541,14 @@ namespace Yarn.Unity
             Assert.IsNotNull(dialogueViews, "No View class (like DialogueUI) was given! Can't run the dialogue without a View class!");
             Assert.IsNotNull(variableStorage, "Variable storage was not set! Can't run the dialogue!");
 
+            // Give each dialogue view the continuation action, which
+            // they'll call to pass on the user intent to move on to the
+            // next line (or interrupt the current one).
+            System.Action continueAction = OnViewUserIntentNextLine;
+            foreach (var dialogueView in dialogueViews) {
+                dialogueView.onUserWantsLineContinuation = continueAction;
+            }
+
             // Ensure that the variable storage has the right stuff in it
             variableStorage.ResetToDefaults();
 

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 
 The MIT License (MIT)
 
@@ -1113,7 +1113,7 @@ namespace Yarn.Unity
             line.Status = newStatus;
 
             foreach (var view in dialogueViews) {
-                view.OnLineStatusChanged(line, previousStatus, newStatus);
+                view.OnLineStatusChanged(line);
             }
         }
 

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -1078,8 +1078,20 @@ namespace Yarn.Unity
                 UpdateLineStatus(CurrentLine, LineStatus.Delivered);
             }
 
-            // TODO: have a flag to automatically proceed to the next line
-            // when the line becomes Delivered?
+            // Should the line automatically become Ended as soon as it's
+            // Delivered?
+            if (continueNextLineOnLineFinished) {
+                // Go ahead and notify the views. 
+                UpdateLineStatus(CurrentLine, LineStatus.Ended);
+
+                // Additionally, tell the views to dismiss the line from
+                // presentation. When each is done, it will notify this
+                // dialogue runner to call DialogueViewCompletedDismissal;
+                // when all have finished, this dialogue runner will tell
+                // the Dialogue to Continue() when all lines are done
+                // dismissing the line.
+                DismissLineFromViews(dialogueViews);                
+            }
         }
 
         /// <summary>

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 
 The MIT License (MIT)
 
@@ -812,15 +812,8 @@ namespace Yarn.Unity
                 foreach (var dialogueView in dialogueViews) {
                     // Mark this dialogue view as active                
                     ActiveDialogueViews.Add(dialogueView);
-                    dialogueView.controllingDialogueRunner = this;
-                    dialogueView.RunLine(new LocalizedLine()
-                    {
-                        TextID = line.ID,
-                        TextLocalized = text,
-                        VoiceOverLocalized = audio,
-                        Substitutions = substitutions,
-                        Status = LineStatus.Running
-                    }, () => DialogueViewCompletedDelivery(dialogueView));
+                    dialogueView.RunLine(CurrentLine, 
+                        () => DialogueViewCompletedDelivery(dialogueView));
                 }
                 return Dialogue.HandlerExecutionType.PauseExecution;
             }

--- a/Runtime/DialogueUI.cs
+++ b/Runtime/DialogueUI.cs
@@ -312,9 +312,9 @@ namespace Yarn.Unity {
             onDialogueLineFinished();
         }
 
-        public override void OnLineStatusChanged(LocalizedLine dialogueLine, LineStatus previousStatus, LineStatus newStatus) {
+        public override void OnLineStatusChanged(LocalizedLine dialogueLine) {
 
-            switch (newStatus)
+            switch (dialogueLine.Status)
             {
                 case LineStatus.Running:
                     // No-op; this line is running

--- a/Runtime/DialogueUI.cs
+++ b/Runtime/DialogueUI.cs
@@ -141,8 +141,9 @@ namespace Yarn.Unity {
 
         /// <summary>
         /// A <see cref="UnityEngine.Events.UnityEvent"/> that is called
-        /// when a line has finished being delivered not just on this
-        /// View but on all Views registered on the <see cref="DialogueRunner"/>.
+        /// when a line has finished being delivered not just on this View
+        /// but on all Views registered on the <see
+        /// cref="DialogueRunner"/>.
         /// </summary>
         /// <remarks>
         /// Use this method to display UI elements like a "continue" button

--- a/Runtime/DialogueUI.cs
+++ b/Runtime/DialogueUI.cs
@@ -125,7 +125,7 @@ namespace Yarn.Unity {
 
         /// <summary>
         /// A <see cref="UnityEngine.Events.UnityEvent"/> that is called
-        /// when a line's text has finished being displayed.
+        /// when the line has finished being displayed by this view.
         /// </summary>
         /// <remarks>
         /// This method is called after <see cref="onLineUpdate"/>. Use
@@ -137,6 +137,7 @@ namespace Yarn.Unity {
         /// is called.
         /// </remarks>
         /// <seealso cref="onLineUpdate"/>
+        /// <seealso cref="onLineFinishDisplaying"/>
         /// <seealso cref="MarkLineComplete"/>
         public UnityEngine.Events.UnityEvent onTextFinishDisplaying;
 
@@ -146,8 +147,12 @@ namespace Yarn.Unity {
         /// </summary>
         /// <remarks>
         /// Use this method to display UI elements like a "continue" button
-        /// in sync with other Views like voice over playback.
+        /// in sync with other <see cref="DialogueViewBase"/> objects, like
+        /// voice over playback.
         /// </remarks>
+        /// <seealso cref="onLineUpdate"/>
+        /// <seealso cref="onTextFinishDisplaying"/>
+        /// <seealso cref="MarkLineComplete"/>        
         public UnityEngine.Events.UnityEvent onLineFinishDisplaying;
 
         /// <summary>

--- a/Runtime/DialogueViewBase.cs
+++ b/Runtime/DialogueViewBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -80,12 +80,8 @@ namespace Yarn.Unity
         /// </remarks>
         /// <param name="dialogueLine">The <see cref="LocalizedLine"/> that
         /// has changed state.</param>
-        /// <param name="previousStatus">The status that the line used to
-        /// have.</param>
-        /// <param name="newStatus">The status that the line now
-        /// has.</param>
         /// <seealso cref="LineStatus"/>
-        public virtual void OnLineStatusChanged(LocalizedLine dialogueLine, LineStatus previousStatus, LineStatus newStatus) {
+        public virtual void OnLineStatusChanged(LocalizedLine dialogueLine) {
             // default implementation is a no-op
         }
 

--- a/Runtime/DialogueViewBase.cs
+++ b/Runtime/DialogueViewBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -29,9 +29,11 @@ namespace Yarn.Unity
     public abstract class DialogueViewBase : MonoBehaviour
     {
         /// <summary>
-        /// The instance of the current line's DialogueRunner
+        /// Represents the method that should be called when this view
+        /// wants the line to be interrupted or to proceed to the next
+        /// line.
         /// </summary>
-        internal DialogueRunner controllingDialogueRunner;
+        internal System.Action onUserWantsLineContinuation;
 
         /// <summary>Signals that a conversation has started.</summary>
         public virtual void DialogueStarted()
@@ -166,9 +168,8 @@ namespace Yarn.Unity
         /// </remarks>
         public void MarkLineComplete()
         {
-            if (controllingDialogueRunner) {
-                controllingDialogueRunner.OnViewUserIntentNextLine();
-            }
+            // Call the continuation callback, if we have it.
+            onUserWantsLineContinuation?.Invoke();
         }
     }
 }

--- a/Runtime/DialogueViewBase.cs
+++ b/Runtime/DialogueViewBase.cs
@@ -6,22 +6,31 @@ using UnityEngine;
 namespace Yarn.Unity
 {
     /// <summary>
-    /// A <see cref="MonoBehaviour"/> that can present the data of a dialogue executed by a <see cref="DialogueRunner"/> to the user. The <see cref="DialogueRunner"/> uses subclasses of this type to relay information to and from the user, and to pause and resume the execution of the <see cref="YarnProgram"/>.
+    /// A <see cref="MonoBehaviour"/> that can present the data of a
+    /// dialogue executed by a <see cref="DialogueRunner"/> to the user.
+    /// The <see cref="DialogueRunner"/> uses subclasses of this type to
+    /// relay information to and from the user, and to pause and resume the
+    /// execution of the <see cref="YarnProgram"/>.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// The term "view" is meant in the broadest sense, e.g. a view on the dialogue (MVVM pattern). Therefore, this abstract class only defines how a specific view on the dialogue should communicate with the <see cref="DialogueRunner"/> (e.g. display text or trigger a voice over clip). How to present the content to the user will be the responsibility of all classes inheriting from this class.
-    /// </para>
-    /// <para>
-    /// The inheriting classes will receive a <see cref="LocalizedLine"/> and can be in one of the stages defined in <see cref="DialogueLineStatus"/> while presenting it.
-    /// </para>
+    /// The term "view" is meant in the broadest sense, e.g. a view on the
+    /// dialogue (MVVM pattern). Therefore, this abstract class only
+    /// defines how a specific view on the dialogue should communicate with
+    /// the <see cref="DialogueRunner"/> (e.g. display text or trigger a
+    /// voice over clip). How to present the content to the user will be
+    /// the responsibility of all classes inheriting from this class.
+    ///
+    /// The inheriting classes will receive a <see cref="LocalizedLine"/>
+    /// and can be in one of the stages defined in <see
+    /// cref="DialogueLineStatus"/> while presenting it.
     /// </remarks>
     /// <seealso cref="DialogueRunner.dialogueViews"/>
     /// <seealso cref="DialogueUI"/>
     public abstract class DialogueViewBase : MonoBehaviour
     {
         /// <summary>
-        /// The status of the <see cref="LocalizedLine"/> currently handled by this <see cref="DialogueViewBase"/> instance.
+        /// The status of the <see cref="LocalizedLine"/> currently handled
+        /// by this <see cref="DialogueViewBase"/> instance.
         /// </summary>
         public enum DialogueLineStatus {
             /// <summary>
@@ -29,22 +38,37 @@ namespace Yarn.Unity
             /// </summary>
             Running,
             /// <summary>
-            /// The line got interrupted while being build up and should complete showing the line asap. View classes should get to the end of the line as fast as possible. A view class showing text would stop building up the text and immediately show the entire line and a view class playing voice over clips would do a very quick fade out and stop playback afterwards.
+            /// The line got interrupted while being build up and should
+            /// complete showing the line asap. View classes should get to
+            /// the end of the line as fast as possible. A view class
+            /// showing text would stop building up the text and
+            /// immediately show the entire line and a view class playing
+            /// voice over clips would do a very quick fade out and stop
+            /// playback afterwards.
             /// </summary>
             Interrupted,
             /// <summary>
-            /// The line has been fully presented to the user. A view class presenting the line as text would be showing the entire line and a view class playing voice over clips would be silent now.
+            /// The line has been fully presented to the user. A view class
+            /// presenting the line as text would be showing the entire
+            /// line and a view class playing voice over clips would be
+            /// silent now.
             /// </summary>
             /// <remarks>
-            /// A line that was previously <see cref="DialogueLineStatus.Interrupted"/> will become <see cref="DialogueLineStatus.Finished"/> once the <see cref="DialogueViewBase"/> has completed the interruption process.
+            /// A line that was previously <see
+            /// cref="DialogueLineStatus.Interrupted"/> will become <see
+            /// cref="DialogueLineStatus.Finished"/> once the <see
+            /// cref="DialogueViewBase"/> has completed the interruption
+            /// process.
             /// </remarks>
             Finished,
             /// <summary>
-            /// The line is about to go away. A view class presenting the line as text would stop showing the line to the user.
+            /// The line is about to go away. A view class presenting the
+            /// line as text would stop showing the line to the user.
             /// </summary>
             Ending,
             /// <summary>
-            /// The line is not being presented anymore in any way to the user.
+            /// The line is not being presented anymore in any way to the
+            /// user.
             /// </summary>
             Ended
         }
@@ -62,7 +86,8 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Called by the <see cref="DialogueRunner"/> to signal that a line should be displayed to the user.
+        /// Called by the <see cref="DialogueRunner"/> to signal that a
+        /// line should be displayed to the user.
         /// </summary>
         /// <remarks>
         /// If this method returns <see
@@ -70,24 +95,30 @@ namespace Yarn.Unity
         /// should not call the <paramref name="onDialogueLineFinished"/>
         /// method.
         /// </remarks>
-        /// <param name="dialogueLine">The content of the line that should be presented to the user.</param>
-        /// <param name="onDialogueLineFinished">The method that should be called after the line has been
-        /// finished.</param>
-        /// <returns>Returns <see cref="Dialogue.HandlerExecutionType.PauseExecution"/> if dialogue should
-        /// wait until the completion handler is called before continuing execution;
-        /// <see cref="Dialogue.HandlerExecutionType.ContinueExecution"/> if dialogue should immediately
-        /// continue running after calling this method.</returns>
-        /// FIXME: If this method is expected to be called only from the DialogueRunner
-        /// then this should be converted into a coroutine and merged with RunLineWithCallback();
+        /// <param name="dialogueLine">The content of the line that should
+        /// be presented to the user.</param>
+        /// <param name="onDialogueLineFinished">The method that should be
+        /// called after the line has been finished.</param>
+        /// <returns>Returns <see
+        /// cref="Dialogue.HandlerExecutionType.PauseExecution"/> if
+        /// dialogue should wait until the completion handler is called
+        /// before continuing execution;
+        /// <see cref="Dialogue.HandlerExecutionType.ContinueExecution"/>
+        /// if dialogue should immediately continue running after calling
+        /// this method.</returns>
+        /// FIXME: If this method is expected to be called only from the
+        /// DialogueRunner then this should be converted into a coroutine
+        /// and merged with RunLineWithCallback();
         public void RunLine(LocalizedLine dialogueLine, Action onDialogueLineFinished) {
             StartCoroutine(RunLineWithCallback(dialogueLine, onDialogueLineFinished));
         }
         /// <summary>
-        /// Run the given <see cref="LocalizedLine"/> on the derived class. The implementation
-        /// will take care of presenting the line to the user e.g. by showing the text or playing 
-        /// the voice over.
+        /// Run the given <see cref="LocalizedLine"/> on the derived class.
+        /// The implementation will take care of presenting the line to the
+        /// user e.g. by showing the text or playing the voice over.
         /// </summary>
-        /// <param name="dialogueLine">The content of the current line that should be presented to the user.</param>
+        /// <param name="dialogueLine">The content of the current line that
+        /// should be presented to the user.</param>
         /// <returns></returns>
         protected abstract IEnumerator RunLine(LocalizedLine dialogueLine);
 
@@ -105,9 +136,11 @@ namespace Yarn.Unity
         /// Finish presenting the current <see cref="LocalizedLine"/>.
         /// </summary>
         /// <remarks>
-        /// Called if the <see cref="DialogueRunner"/> has received the user's request on one of the 
-        /// <see cref="DialogueRunner.dialogueViews"/> classes derived from <see cref="DialogueViewBase"/> to 
-        /// finish presenting the current line.
+        /// Called if the <see cref="DialogueRunner"/> has received the
+        /// user's request on one of the 
+        /// <see cref="DialogueRunner.dialogueViews"/> classes derived from
+        /// <see cref="DialogueViewBase"/> to finish presenting the current
+        /// line.
         /// </remarks>
         internal void FinishRunningCurrentLine() {
             dialogueLineStatus = DialogueLineStatus.Interrupted;
@@ -115,21 +148,29 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Finish presenting the current <see cref="LocalizedLine"/> on the derived class.
+        /// Finish presenting the current <see cref="LocalizedLine"/> on
+        /// the derived class.
         /// </summary>
         /// <remarks>
-        /// It is OK to apply quick fade outs. Because this is not a coroutine, it is advisable to do that
-        /// inside of the active <see cref="DialogueViewBase.RunLine(LocalizedLine)"/> coroutine on the
-        /// derived class. In that case, this method should only inform the active coroutine on the
-        /// derived class to quickly finish presenting the current line.
+        /// It is OK to apply quick fade outs. Because this is not a
+        /// coroutine, it is advisable to do that inside of the active <see
+        /// cref="DialogueViewBase.RunLine(LocalizedLine)"/> coroutine on
+        /// the derived class. In that case, this method should only inform
+        /// the active coroutine on the derived class to quickly finish
+        /// presenting the current line.
         /// </remarks>
         protected abstract void FinishCurrentLine();
 
         /// <summary>
-        /// Called by the <see cref="DialogueRunner"/> to inform all classes inheriting from <see cref="DialogueViewBase"/> that they all finished presenting the current <see cref="LocalizedLine"/> to the user.
+        /// Called by the <see cref="DialogueRunner"/> to inform all
+        /// classes inheriting from <see cref="DialogueViewBase"/> that
+        /// they all finished presenting the current <see
+        /// cref="LocalizedLine"/> to the user.
         /// </summary>
         /// <remarks>
-        /// This can be used to trigger sounds in sync when a line has been fully presented or to show the user a prompt to go to the next line.
+        /// This can be used to trigger sounds in sync when a line has been
+        /// fully presented or to show the user a prompt to go to the next
+        /// line.
         /// </remarks>
         protected internal abstract void OnFinishedLineOnAllViews();
 
@@ -137,9 +178,10 @@ namespace Yarn.Unity
         /// End the current <see cref="LocalizedLine"/>.
         /// </summary>
         /// <remarks>
-        /// This should only be called from  the <see cref="DialogueRunner"/> if all <see 
-        /// cref="DialogueRunner.dialogueViews"/> have finished presenting the current line (e.g. finished
-        /// quick fade outs).
+        /// This should only be called from  the <see
+        /// cref="DialogueRunner"/> if all <see
+        /// cref="DialogueRunner.dialogueViews"/> have finished presenting
+        /// the current line (e.g. finished quick fade outs).
         /// </remarks>
         /// <param name="onDialogueLineCompleted"></param>
         /// <returns></returns>
@@ -159,7 +201,8 @@ namespace Yarn.Unity
         protected abstract IEnumerator EndCurrentLine();
 
         /// <summary>
-        /// Called by the <see cref="DialogueRunner"/> to signal that a set of options should be displayed to the user.
+        /// Called by the <see cref="DialogueRunner"/> to signal that a set
+        /// of options should be displayed to the user.
         /// </summary>
         /// <remarks>
         /// When this method is called, the <see cref="DialogueRunner"/>
@@ -173,18 +216,22 @@ namespace Yarn.Unity
         public abstract void RunOptions(DialogueOption[] dialogueOptions, Action<int> onOptionSelected);
 
         /// <summary>
-        /// Called by the <see cref="DialogueRunner"/> to signal that the end of a node has been reached.
+        /// Called by the <see cref="DialogueRunner"/> to signal that the
+        /// end of a node has been reached.
         /// </summary>
         /// <remarks>
-        /// This method may be called multiple times before <see cref="DialogueComplete"/> is called.
-        /// If this method returns <see
-        /// cref="Dialogue.HandlerExecutionType.ContinueExecution"/>, do
-        /// not call the <paramref name="onComplete"/> method.
+        /// This method may be called multiple times before <see
+        /// cref="DialogueComplete"/> is called. If this method returns
+        /// <see cref="Dialogue.HandlerExecutionType.ContinueExecution"/>,
+        /// do not call the <paramref name="onComplete"/> method.
         /// </remarks>
-        /// <param name="nextNode">The name of the next node that is being entered.</param>
+        /// <param name="nextNode">The name of the next node that is being
+        /// entered.</param>
         /// <param name="onComplete">A method that should be called to
-        /// indicate that the DialogueRunner should continue executing.</param>
-        /// <inheritdoc cref="RunLine(Line, ILineLocalisationProvider, Action)"/>
+        /// indicate that the DialogueRunner should continue
+        /// executing.</param>
+        /// <inheritdoc cref="RunLine(Line, ILineLocalisationProvider,
+        /// Action)"/>
         /// FIXME: This doesn't seem to be called anymore ...?
         public virtual Dialogue.HandlerExecutionType NodeComplete(string nextNode, Action onComplete)
         {
@@ -193,7 +240,8 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Called by the <see cref="DialogueRunner"/> to signal that the dialogue has ended.
+        /// Called by the <see cref="DialogueRunner"/> to signal that the
+        /// dialogue has ended.
         /// </summary>
         public virtual void DialogueComplete()
         {
@@ -204,20 +252,19 @@ namespace Yarn.Unity
         /// Signals that the user wants to go to the next line.
         /// </summary>
         /// <remarks>
-        /// <para>
         /// This method is generally called by a "continue" button, and
         /// causes the DialogueUI to signal the <see
         /// cref="DialogueRunner"/> to proceed to the next piece of
         /// content.
-        /// </para>
-        /// <para>
+        ///
         /// If this method is called before the line has finished appearing
         /// (that is, before the status changes to 
         /// <see cref="DialogueLineStatus.Finished"/>), the 
-        /// <see cref="DialogueRunner"/> will call <see cref="FinishRunningCurrentLine"/> 
-        /// on all <see cref="DialogueViewBase"/> derived classes and wait for them to finish
-        /// before calling <see cref="EndCurrentLine(Action)"/> on all of them.
-        /// </para>
+        /// <see cref="DialogueRunner"/> will call <see
+        /// cref="FinishRunningCurrentLine"/> 
+        /// on all <see cref="DialogueViewBase"/> derived classes and wait
+        /// for them to finish before calling <see
+        /// cref="EndCurrentLine(Action)"/> on all of them.
         /// </remarks>
         public void MarkLineComplete()
         {
@@ -227,7 +274,8 @@ namespace Yarn.Unity
         }
 
         /// <summary>
-        /// Signals that the user wants to go to the end of the current line.
+        /// Signals that the user wants to go to the end of the current
+        /// line.
         /// </summary>
         public void FinishLine() {
             if (dialogueRunnerCurrentLine) {

--- a/Runtime/LanguageToAudioclip.cs
+++ b/Runtime/LanguageToAudioclip.cs
@@ -26,8 +26,8 @@ public class LanguageToAudioclip {
 #if ADDRESSABLES
     /// <summary>
     /// The <see cref="AudioClip"/> stored as <see cref="AssetReference"/> 
-    /// associated with the <see cref="language"/> ID. Needs to be part of an 
-    /// Addressable group and will be loaded asynchronously.
+    /// associated with the <see cref="language"/> ID. Needs to be part of
+    /// an Addressable group and will be loaded asynchronously.
     /// </summary>
     public AssetReference audioClipAddressable;
 #endif

--- a/Runtime/LinetagToLanguage.cs
+++ b/Runtime/LinetagToLanguage.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 
 /// <summary>
-/// A linetag and it's corresponding <see cref="UnityEngine.AudioClip"/> per available language for voice over dialogues.
+/// A linetag and it's corresponding <see cref="UnityEngine.AudioClip"/>
+/// per available language for voice over dialogues.
 /// </summary>
 [Serializable]
 public class LinetagToLanguage {
@@ -15,7 +16,8 @@ public class LinetagToLanguage {
     public string linetag;
 
     /// <summary>
-    /// The <see cref="UnityEngine.AudioClip"/>s associated with this <see cref="linetag"/> per available language.
+    /// The <see cref="UnityEngine.AudioClip"/>s associated with this <see
+    /// cref="linetag"/> per available language.
     /// </summary>
     public LanguageToAudioclip[] languageToAudioclip = Array.Empty<LanguageToAudioclip>();
 }

--- a/Runtime/Prefabs/Dialogue.prefab
+++ b/Runtime/Prefabs/Dialogue.prefab
@@ -1124,13 +1124,19 @@ MonoBehaviour:
   variableStorage: {fileID: 5935829475398715335}
   dialogueViews:
   - {fileID: 5935829475398715334}
-  _voiceOverPlayback: {fileID: 0}
   startNode: 
   startAutomatically: 0
+  continueNextLineOnLineFinished: 0
+  onNodeStart:
+    m_PersistentCalls:
+      m_Calls: []
   onNodeComplete:
     m_PersistentCalls:
       m_Calls: []
   onDialogueComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  onCommand:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &5935829475398715334
@@ -1183,6 +1189,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  onTextFinishDisplaying:
+    m_PersistentCalls:
+      m_Calls: []
   onLineFinishDisplaying:
     m_PersistentCalls:
       m_Calls:
@@ -1240,9 +1249,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   onOptionsEnd:
-    m_PersistentCalls:
-      m_Calls: []
-  onCommand:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &5935829475398715335

--- a/Runtime/Preferences.cs
+++ b/Runtime/Preferences.cs
@@ -3,7 +3,8 @@ using System;
 using System.Globalization;
 
 /// <summary>
-/// Yarn preferences made by the user that should not be stored in a project or in a build.
+/// Yarn preferences made by the user that should not be stored in a
+/// project or in a build.
 /// </summary>
 [Serializable]
 public class Preferences : ScriptableObject {
@@ -31,8 +32,8 @@ public class Preferences : ScriptableObject {
     private string _preferencesPath;
 
     /// <summary>
-    /// The text language preference that was read from disk.
-    /// Used to detect changes to reduce writing to disk.
+    /// The text language preference that was read from disk. Used to
+    /// detect changes to reduce writing to disk.
     /// </summary>
     private string _textLanguageFromDisk;
 

--- a/Runtime/ProjectSettings.cs
+++ b/Runtime/ProjectSettings.cs
@@ -2,7 +2,8 @@
 using UnityEngine;
 
 /// <summary>
-/// Yarn's project wide settings that will automatically be included in a build and not altered after that.
+/// Yarn's project wide settings that will automatically be included in a
+/// build and not altered after that.
 /// </summary>
 [System.Serializable]
 public class ProjectSettings : ScriptableObject {
@@ -11,12 +12,15 @@ public class ProjectSettings : ScriptableObject {
     /// </summary>
     [SerializeField]
     private List<string> _textProjectLanguages = new List<string>();
+
     /// <summary>
     /// Project wide available text languages
     /// </summary>
     public static List<string> TextProjectLanguages => Instance._textProjectLanguages;
+
     /// <summary>
-    /// Project wide default text language. Returns null if no default languages exists.
+    /// Project wide default text language. Returns null if no default
+    /// languages exists.
     /// </summary>
     public static string TextProjectLanguageDefault => TextProjectLanguages.Count > 0 ? TextProjectLanguages[0] : null;
 
@@ -25,12 +29,15 @@ public class ProjectSettings : ScriptableObject {
     /// </summary>
     [SerializeField]
     private List<string> _audioProjectLanguages = new List<string>();
+
     /// <summary>
     /// Project wide available audio voice over languages
     /// </summary>
     public static List<string> AudioProjectLanguages => Instance._audioProjectLanguages;
+    
     /// <summary>
-    /// Project wide default audio language. Returns null if no default languages exists.
+    /// Project wide default audio language. Returns null if no default
+    /// languages exists.
     /// </summary>
     public static string AudioProjectLanguageDefault => AudioProjectLanguages.Count > 0 ? AudioProjectLanguages[0] : null;
 
@@ -49,16 +56,16 @@ public class ProjectSettings : ScriptableObject {
     private bool _addressableVoiceOverAudioClips = false;
 
     /// <summary>
-    /// False (default) when VoiceOver AudioClip should be directly 
-    /// referenced and loaded. True if the Addressable system 
-    /// should be used.
+    /// False (default) when VoiceOver AudioClip should be directly
+    /// referenced and loaded. True if the Addressable system should be
+    /// used.
     /// </summary>
     public static bool AddressableVoiceOverAudioClips { get => Instance._addressableVoiceOverAudioClips; set => Instance._addressableVoiceOverAudioClips = value; }
 #endif
 
     /// <summary>
-    /// Makes sure that there's always an instance of this
-    /// class alive upon access.
+    /// Makes sure that there's always an instance of this class alive upon
+    /// access.
     /// </summary>
     private static ProjectSettings Instance {
         get {

--- a/Runtime/VoiceOverPlaybackFmod.cs
+++ b/Runtime/VoiceOverPlaybackFmod.cs
@@ -1,28 +1,28 @@
 ﻿//--------------------------------------------------------------------
 //
-// This is a Unity behaviour script that demonstrates how to use
-// Programmer Sounds and the Audio Table in your game code for 
-// the use with the yarn dialogue system. It has been slightly
-// altered from this place originally: 
+// This is a Unity behaviour script that demonstrates how to use Programmer
+// Sounds and the Audio Table in your game code for the use with the yarn
+// dialogue system. It has been slightly altered from this place
+// originally:
 // https://fmod.com/resources/documentation-unity?version=2.0&page=examples-programmer-sounds.html
 //
 // Programmer sounds allows the game code to receive a callback at a
-// sound-designer specified time and return a sound object to the be
-// played within the event.
+// sound-designer specified time and return a sound object to the be played
+// within the event.
 //
-// The audio table is a group of audio files compressed in a Bank that
-// are not associated with any event and can be accessed by a string key.
+// The audio table is a group of audio files compressed in a Bank that are
+// not associated with any event and can be accessed by a string key.
 //
 // Together these two features allow for an efficient implementation of
-// dialogue systems where the sound designer can build a single template 
+// dialogue systems where the sound designer can build a single template
 // event and different dialogue sounds can be played through it at runtime.
 //
-// This script will play one of three pieces of dialog through an event
-// on a key press from the player.
+// This script will play one of three pieces of dialog through an event on
+// a key press from the player.
 //
 // This document assumes familiarity with Unity scripting. See
-// https://unity3d.com/learn/tutorials/topics/scripting for resources
-// on learning Unity scripting. 
+// https://unity3d.com/learn/tutorials/topics/scripting for resources on
+// learning Unity scripting. 
 //
 //--------------------------------------------------------------------
 #if FMOD_2_OR_NEWER
@@ -37,25 +37,28 @@ namespace Yarn.Unity {
         FMOD.Studio.EVENT_CALLBACK dialogueCallback;
 
         /// <summary>
-        /// The event name of the programmer's sound from the fmod studio project that we trigger voice dialogues from
+        /// The event name of the programmer's sound from the fmod studio
+        /// project that we trigger voice dialogues from
         /// </summary>
         [FMODUnity.EventRef]
         public string fmodEvent = "";
 
         /// <summary>
-        /// When true, the Runner has signaled to finish the current line 
+        /// When true, the Runner has signaled to finish the current line
         /// asap.
         /// </summary>
         private bool finishCurrentLine = false;
 
         /// <summary>
-        /// FMOD callbacks are received via a static method. To support multiple instances of this playback class,
-        /// we track the last fired FMOD event per instance here.
+        /// FMOD callbacks are received via a static method. To support
+        /// multiple instances of this playback class, we track the last
+        /// fired FMOD event per instance here.
         /// </summary>
         private FMOD.Studio.EventInstance _lastVoiceOverEvent;
 
         /// <summary>
-        /// All instances currently alive of this class. Necessary to properly deal with static callbacks from FMOD.
+        /// All instances currently alive of this class. Necessary to
+        /// properly deal with static callbacks from FMOD.
         /// </summary>
         private static List<VoiceOverPlaybackFmod> _instances = new List<VoiceOverPlaybackFmod>();
 
@@ -68,14 +71,16 @@ namespace Yarn.Unity {
         }
 
         void Start() {
-            // Explicitly create the delegate object and assign it to a member so it doesn't get freed
-            // by the garbage collected while it's being used
+            // Explicitly create the delegate object and assign it to a
+            // member so it doesn't get freed by the garbage collected
+            // while it's being used
             dialogueCallback = new FMOD.Studio.EVENT_CALLBACK(DialogueEventCallback);
         }
 
-        // TODO: There's currently no way for other parts of the system to tell
-        // this object that audio has been interrupted (e.g due to the user
-        // requesting to go to the next line in the middle of audio playback.)
+        // TODO: There's currently no way for other parts of the system to
+        // tell this object that audio has been interrupted (e.g due to the
+        // user requesting to go to the next line in the middle of audio
+        // playback.)
 
         [AOT.MonoPInvokeCallback(typeof(FMOD.Studio.EVENT_CALLBACK))]
         static FMOD.RESULT DialogueEventCallback(FMOD.Studio.EVENT_CALLBACK_TYPE type, FMOD.Studio.EventInstance instance, IntPtr parameterPtr) {
@@ -124,7 +129,8 @@ namespace Yarn.Unity {
                     }
                     break;
                 case FMOD.Studio.EVENT_CALLBACK_TYPE.DESTROYED:
-                    // Now the event has been destroyed, unpin the string memory so it can be garbage collected
+                    // Now the event has been destroyed, unpin the string
+                    // memory so it can be garbage collected
                     stringHandle.Free();
                     break;
             }
@@ -134,7 +140,8 @@ namespace Yarn.Unity {
         protected override IEnumerator RunLine(LocalizedLine dialogueLine) {
             finishCurrentLine = false;
 
-            // Check if this instance is currently playing back another voice over in which case we stop it
+            // Check if this instance is currently playing back another
+            // voice over in which case we stop it
             if (_lastVoiceOverEvent.isValid()) {
                 _lastVoiceOverEvent.stop(FMOD.Studio.STOP_MODE.ALLOWFADEOUT);
             }
@@ -150,7 +157,8 @@ namespace Yarn.Unity {
 
             _lastVoiceOverEvent = dialogueInstance;
 
-            // Pin the key string in memory and pass a pointer through the user data
+            // Pin the key string in memory and pass a pointer through the
+            // user data
             GCHandle stringHandle = GCHandle.Alloc(dialogueLine.TextID.Remove(0, 5), GCHandleType.Pinned);
             dialogueInstance.setUserData(GCHandle.ToIntPtr(stringHandle));
 

--- a/Runtime/VoiceOverPlaybackUnity.cs
+++ b/Runtime/VoiceOverPlaybackUnity.cs
@@ -4,11 +4,13 @@ using UnityEngine;
 
 namespace Yarn.Unity {
     /// <summary>
-    /// Handles playback of voice over <see cref="AudioClip"/>s referenced on <see cref="YarnProgram"/>s.
+    /// Handles playback of voice over <see cref="AudioClip"/>s referenced
+    /// on <see cref="YarnProgram"/>s.
     /// </summary>
     public class VoiceOverPlaybackUnity : DialogueViewBase {
         /// <summary>
-        /// The fade out time when <see cref="FinishCurrentLine"/> is called.
+        /// The fade out time when <see cref="FinishCurrentLine"/> is
+        /// called.
         /// </summary>
         public float fadeOutTimeOnLineFinish = 0.05f;
 
@@ -16,8 +18,8 @@ namespace Yarn.Unity {
         private AudioSource audioSource;
 
         /// <summary>
-        /// When true, the <see cref="DialogueRunner"/> has signaled to finish the current line
-        /// asap.
+        /// When true, the <see cref="DialogueRunner"/> has signaled to
+        /// finish the current line asap.
         /// </summary>
         private bool finishCurrentLine = false;
 
@@ -29,7 +31,8 @@ namespace Yarn.Unity {
         }
 
         /// <summary>
-        /// Start playback of the associated voice over <see cref="AudioClip"/> of the given <see cref="LocalizedLine"/>.
+        /// Start playback of the associated voice over <see
+        /// cref="AudioClip"/> of the given <see cref="LocalizedLine"/>.
         /// </summary>
         /// <param name="dialogueLine"></param>
         /// <returns></returns>
@@ -44,7 +47,8 @@ namespace Yarn.Unity {
                 yield break;
             }
             if (audioSource.isPlaying) {
-                // Usually, this shouldn't happen because the DialogueRunner finishes and ends a line first
+                // Usually, this shouldn't happen because the
+                // DialogueRunner finishes and ends a line first
                 audioSource.Stop();
             }
             audioSource.PlayOneShot(voiceOverClip);
@@ -70,8 +74,9 @@ namespace Yarn.Unity {
         }
 
         /// <summary>
-        /// Instruct playback of the current <see cref="LocalizedLine"/>'s voice over <see cref="AudioClip"/> to stop asap.
-        /// Applies fade out defined by <see cref="fadeOutTimeOnLineFinish"/>.
+        /// Instruct playback of the current <see cref="LocalizedLine"/>'s
+        /// voice over <see cref="AudioClip"/> to stop asap. Applies fade
+        /// out defined by <see cref="fadeOutTimeOnLineFinish"/>.
         /// </summary>
         protected override void FinishCurrentLine() {
             finishCurrentLine = true;
@@ -83,7 +88,8 @@ namespace Yarn.Unity {
         }
 
         /// <summary>
-        /// YarnSpinner's implementation of voice over playback does nothing when presenting an option.
+        /// Yarn Spinner's implementation of voice over playback does
+        /// nothing when presenting an option.
         /// </summary>
         /// <param name="dialogueOptions"></param>
         /// <param name="onOptionSelected"></param>
@@ -92,7 +98,8 @@ namespace Yarn.Unity {
         }
 
         /// <summary>
-        /// YarnSpinner's implementation of voice over playback does nothing when all Views finished a line.
+        /// Yarn Spinner's implementation of voice over playback does
+        /// nothing when all Views finished a line.
         /// </summary>
         /// <param name="dialogueOptions"></param>
         /// <param name="onOptionSelected"></param>

--- a/Runtime/VoiceOverPlaybackUnity.cs
+++ b/Runtime/VoiceOverPlaybackUnity.cs
@@ -101,9 +101,9 @@ namespace Yarn.Unity {
             // Do nothing
         }
 
-        public override void OnLineStatusChanged(LocalizedLine dialogueLine, LineStatus previousStatus, LineStatus newStatus)
+        public override void OnLineStatusChanged(LocalizedLine dialogueLine)
         {
-            switch (newStatus)
+            switch (dialogueLine.Status)
             {
                 case LineStatus.Running:
                     // Nothing to do here - continue running.

--- a/Runtime/VoiceOverPlaybackUnity.cs
+++ b/Runtime/VoiceOverPlaybackUnity.cs
@@ -36,7 +36,7 @@ namespace Yarn.Unity {
         /// </summary>
         /// <param name="dialogueLine"></param>
         /// <returns></returns>
-        protected override IEnumerator RunLine(LocalizedLine dialogueLine) {
+        public override void RunLine(LocalizedLine dialogueLine, Action onDialogueLineFinished) {
             finishCurrentLine = false;
 
             // Get the localized voice over audio clip
@@ -44,7 +44,8 @@ namespace Yarn.Unity {
 
             if (!voiceOverClip) {
                 Debug.Log("Playing voice over failed since the AudioClip of the voice over audio language or the base language was null.", gameObject);
-                yield break;
+                onDialogueLineFinished();
+                return;
             }
             if (audioSource.isPlaying) {
                 // Usually, this shouldn't happen because the
@@ -53,12 +54,24 @@ namespace Yarn.Unity {
             }
             audioSource.PlayOneShot(voiceOverClip);
 
+            StartCoroutine(DoPlayback(onDialogueLineFinished));
+            
+        }
+
+        private IEnumerator DoPlayback(Action onDialogueLineFinished) {
+
+            // The audioSource started playing before this coroutine
+            // started, so as long as the line hasn't been interrupted, we
+            // don't need to do anything except wait.
             while (audioSource.isPlaying && !finishCurrentLine) {
                 yield return null;
             }
 
-            // Fade out voice over clip
+            // But if the line _does_ become interrupted, we need to wrap
+            // up the playback as quickly as we can. We do this here with a
+            // fade-out to zero over fadeOutTimeOnLineFinish seconds.
             if (audioSource.isPlaying && finishCurrentLine) {
+                // Fade out voice over clip            
                 float lerpPosition = 0f;
                 float volumeFadeStart = audioSource.volume;
                 while (audioSource.volume != 0) {
@@ -71,20 +84,11 @@ namespace Yarn.Unity {
             } else {
                 audioSource.Stop();
             }
-        }
 
-        /// <summary>
-        /// Instruct playback of the current <see cref="LocalizedLine"/>'s
-        /// voice over <see cref="AudioClip"/> to stop asap. Applies fade
-        /// out defined by <see cref="fadeOutTimeOnLineFinish"/>.
-        /// </summary>
-        protected override void FinishCurrentLine() {
-            finishCurrentLine = true;
-        }
-
-        protected override IEnumerator EndCurrentLine() {
-            // Avoid skipping lines if textSpeed == 0
-            yield return new WaitForEndOfFrame();
+            // We've finished our playback at this point, either by waiting
+            // normally or by interrupting it with a fadeout. We can now
+            // signal that the line delivery has finished.
+            onDialogueLineFinished();
         }
 
         /// <summary>
@@ -97,14 +101,37 @@ namespace Yarn.Unity {
             // Do nothing
         }
 
-        /// <summary>
-        /// Yarn Spinner's implementation of voice over playback does
-        /// nothing when all Views finished a line.
-        /// </summary>
-        /// <param name="dialogueOptions"></param>
-        /// <param name="onOptionSelected"></param>
-        protected internal override void OnFinishedLineOnAllViews() {
-            // Do nothing
+        public override void OnLineStatusChanged(LocalizedLine dialogueLine, LineStatus previousStatus, LineStatus newStatus)
+        {
+            switch (newStatus)
+            {
+                case LineStatus.Running:
+                    // Nothing to do here - continue running.
+                    break;
+                case LineStatus.Interrupted:
+                    // The user wants us to wrap up the audio quickly. The
+                    // DoPlayback coroutine will apply the fade out defined
+                    // by fadeOutTimeOnLineFinish.
+                    finishCurrentLine = true;
+                    break;
+                case LineStatus.Delivered:
+                    // The line has finished delivery on all views. Nothing
+                    // left to do for us, since the audio will have already
+                    // finished playing out.
+                    break;
+                case LineStatus.Ended:
+                    // The line is being dismissed; we should ensure that
+                    // audio playback has ended.
+                    audioSource.Stop();            
+                    break;
+            }
+        }
+
+        public override void DismissLine(Action onDismissalComplete)
+        {
+            // Nothing left to do here - the audio playback will have
+            // already ended.
+            onDismissalComplete();
         }
     }
 }

--- a/Runtime/YarnLinesAsCanvasText.cs
+++ b/Runtime/YarnLinesAsCanvasText.cs
@@ -23,8 +23,8 @@ namespace Yarn.Unity {
         }
 
         /// <summary>
-        /// Reload the string table and update the UI elements.
-        /// Useful if the languages preferences were changed.
+        /// Reload the string table and update the UI elements. Useful if
+        /// the languages preferences were changed.
         /// </summary>
         public void OnTextLanguagePreferenceChanged () {
             LoadStringTable();
@@ -44,7 +44,8 @@ namespace Yarn.Unity {
         }
 
         /// <summary>
-        /// Update all UI components to the yarn lines loaded from yarnScript.
+        /// Update all UI components to the yarn lines loaded from
+        /// yarnScript.
         /// </summary>
         private void UpdateTextOnUiElements() {
             var index = 0;

--- a/Runtime/YarnProgram.cs
+++ b/Runtime/YarnProgram.cs
@@ -10,7 +10,9 @@ using UnityEngine.ResourceManagement.AsyncOperations;
 using Yarn;
 
 /// <summary>
-/// A <see cref="ScriptableObject"/> created from a yarn file that stores the compiled Yarn program, all lines of text with their associated IDs, translations and voice over <see cref="AudioClip"/>s.
+/// A <see cref="ScriptableObject"/> created from a yarn file that stores
+/// the compiled Yarn program, all lines of text with their associated IDs,
+/// translations and voice over <see cref="AudioClip"/>s.
 /// </summary>
 public class YarnProgram : ScriptableObject
 {
@@ -25,7 +27,8 @@ public class YarnProgram : ScriptableObject
     public TextAsset baseLocalisationStringTable;
 
     /// <summary>
-    /// The language ID (e.g. "en" or "de") of the base language (the language the Yarn file is written in).
+    /// The language ID (e.g. "en" or "de") of the base language (the
+    /// language the Yarn file is written in).
     /// </summary>
     [SerializeField]
     public string baseLocalizationId;
@@ -43,7 +46,8 @@ public class YarnProgram : ScriptableObject
     public LinetagToLanguage[] voiceOvers = new LinetagToLanguage[0];
 
     /// <summary>
-    /// Deserializes a compiled Yarn program from the stored bytes in this object.
+    /// Deserializes a compiled Yarn program from the stored bytes in this
+    /// object.
     /// </summary>
     /// <returns></returns>
     public Program GetProgram() {
@@ -52,7 +56,8 @@ public class YarnProgram : ScriptableObject
 
 
     /// <summary>
-    /// Returns a tagged string table from all lines available on this yarn asset in the language given in preferences.
+    /// Returns a tagged string table from all lines available on this yarn
+    /// asset in the language given in preferences.
     /// </summary>
     /// <returns></returns>
     public Dictionary<string, string> GetStringTable() {
@@ -68,9 +73,11 @@ public class YarnProgram : ScriptableObject
     }
 
     /// <summary>
-    /// Returns a tagged string table from all lines available on this yarn asset in the given language.
+    /// Returns a tagged string table from all lines available on this yarn
+    /// asset in the given language.
     /// </summary>
-    /// <param name="languageId">The language id of the returned string table.</param>
+    /// <param name="languageId">The language id of the returned string
+    /// table.</param>
     /// <returns></returns>
     public Dictionary<string, string> GetStringTable (string languageId) {
         if (languageId == baseLocalizationId) {
@@ -83,9 +90,11 @@ public class YarnProgram : ScriptableObject
     }
 
     /// <summary>
-    /// Returns a tagged string table from all lines available on this yarn asset.
+    /// Returns a tagged string table from all lines available on this yarn
+    /// asset.
     /// </summary>
-    /// <param name="stringTable">The (localized) string table of this yarn asset to load.</param>
+    /// <param name="stringTable">The (localized) string table of this yarn
+    /// asset to load.</param>
     /// <returns></returns>
     public static Dictionary<string, string> GetStringTable (TextAsset stringTable) {
         Dictionary<string, string> strings = new Dictionary<string, string>();
@@ -94,7 +103,8 @@ public class YarnProgram : ScriptableObject
         }
 
         // Use the invariant culture when parsing the CSV to ensure parsing
-        // with the correct separator instead of the user's locale separator
+        // with the correct separator instead of the user's locale
+        // separator
         var configuration = new CsvHelper.Configuration.Configuration(
             System.Globalization.CultureInfo.InvariantCulture
         );
@@ -114,36 +124,46 @@ public class YarnProgram : ScriptableObject
 
 
     /// <summary>
-    /// Returns all associated <see cref="AudioClip"/>s for all available Line IDs of this
-    /// <see cref="YarnProgram"/> for the language set in <see cref="Preferences"/>.
+    /// Returns all associated <see cref="AudioClip"/>s for all available
+    /// Line IDs of this
+    /// <see cref="YarnProgram"/> for the language set in <see
+    /// cref="Preferences"/>.
     /// </summary>
-    /// <returns>A collection of all <see cref="AudioClip"/>s (value) associated with their 
-    /// linetag/StringID (key) that are available on this <see cref="YarnProgram"/>.</returns>
+    /// <returns>A collection of all <see cref="AudioClip"/>s (value)
+    /// associated with their linetag/StringID (key) that are available on
+    /// this <see cref="YarnProgram"/>.</returns>
     public Dictionary<string, AudioClip> GetVoiceOversOfLanguage() {
         return GetVoiceOversOfLanguage(Preferences.AudioLanguage);
     }
 
     /// <summary>
-    /// Returns all associated <see cref="AudioClip"/>s for all available Line IDs for the given
-    /// language ID. Returns the <see cref="AudioClip"/>s of the language set in <see 
+    /// Returns all associated <see cref="AudioClip"/>s for all available
+    /// Line IDs for the given language ID. Returns the <see
+    /// cref="AudioClip"/>s of the language set in <see
     /// cref="Preferences"/> if no parameter is given.
     /// </summary>
-    /// <param name="languageId">The ID of the language the requested voice overs.</param>
-    /// <returns>A collection of all <see cref="AudioClip"/>s (value) associated with their
-    /// linetag/StringID (key) that are available on this <see cref="YarnProgram"/>.</returns>
+    /// <param name="languageId">The ID of the language the requested voice
+    /// overs.</param>
+    /// <returns>A collection of all <see cref="AudioClip"/>s (value)
+    /// associated with their linetag/StringID (key) that are available on
+    /// this <see cref="YarnProgram"/>.</returns>
     public Dictionary<string, AudioClip> GetVoiceOversOfLanguage(string languageId) {
         return GetVoiceOversOfLanguage(languageId, voiceOvers);
     }
 
     /// <summary>
-    /// Returns all associated <see cref="AudioClip"/>s for all available Line IDs for the given
-    /// language ID. Returns the <see cref="AudioClip"/>s of the language set in <see 
+    /// Returns all associated <see cref="AudioClip"/>s for all available
+    /// Line IDs for the given language ID. Returns the <see
+    /// cref="AudioClip"/>s of the language set in <see
     /// cref="Preferences"/> if no parameter is given.
     /// </summary>
-    /// <param name="languageId">The ID of the language the requested voice overs.</param>
-    /// <param name="voiceOvers">The voice overs array to get a specific language of voice overs from.</param>
-    /// <returns>A collection of all <see cref="AudioClip"/>s (value) associated with their
-    /// linetag/StringID (key) that are available on this <see cref="YarnProgram"/>.</returns>
+    /// <param name="languageId">The ID of the language the requested voice
+    /// overs.</param>
+    /// <param name="voiceOvers">The voice overs array to get a specific
+    /// language of voice overs from.</param>
+    /// <returns>A collection of all <see cref="AudioClip"/>s (value)
+    /// associated with their linetag/StringID (key) that are available on
+    /// this <see cref="YarnProgram"/>.</returns>
     public static Dictionary<string, AudioClip> GetVoiceOversOfLanguage(string languageId, LinetagToLanguage[] voiceOvers) {
         Dictionary<string, AudioClip> voiceOversOfPreferredLanguage = new Dictionary<string, AudioClip>();
         if (string.IsNullOrEmpty(languageId)) {
@@ -163,13 +183,19 @@ public class YarnProgram : ScriptableObject
 
 #if ADDRESSABLES
     /// <summary>
-    /// Asynchronously loads all associated <see cref="AudioClip"/>s for all available Line IDs of this <see cref="YarnProgram"/>
-    /// for the language set in <see cref="Preferences"/>. Will return every single voice over once it completed loading via the
-    /// given callback action provided as parameter.
+    /// Asynchronously loads all associated <see cref="AudioClip"/>s for
+    /// all available Line IDs of this <see cref="YarnProgram"/>
+    /// for the language set in <see cref="Preferences"/>. Will return
+    /// every single voice over once it completed loading via the given
+    /// callback action provided as parameter.
     /// </summary>
-    /// <param name="action">The action to call after the loading of each voice over <see cref="AudioClip"/> completed. The action should create a collection associating the linetags/StringIDs with the corresponding voice over.</param>
-    /// <returns>A collection of <see cref="Task"/>s loading all voice over <see cref="AudioClip"/>s available on 
-    /// this <see cref="YarnProgram"/>.</returns>
+    /// <param name="action">The action to call after the loading of each
+    /// voice over <see cref="AudioClip"/> completed. The action should
+    /// create a collection associating the linetags/StringIDs with the
+    /// corresponding voice over.</param>
+    /// <returns>A collection of <see cref="Task"/>s loading all voice over
+    /// <see cref="AudioClip"/>s available on this <see
+    /// cref="YarnProgram"/>.</returns>
     public async Task<IEnumerable<AudioClip>> GetVoiceOversOfLanguageAsync(Action<string, AudioClip> action) {
         List<Task<AudioClip>> listOfTasks = new List<Task<AudioClip>>();
         foreach (var linetag in voiceOvers) {

--- a/Runtime/YarnSettingsHelper.cs
+++ b/Runtime/YarnSettingsHelper.cs
@@ -3,7 +3,8 @@ using System.IO;
 using UnityEngine;
 
 /// <summary>
-/// Provides methods for loading and saving a <see cref="ScriptableObject"/> class used for settings.
+/// Provides methods for loading and saving a <see
+/// cref="ScriptableObject"/> class used for settings.
 /// </summary>
 public static class YarnSettingsHelper {
     /// <summary>
@@ -13,8 +14,9 @@ public static class YarnSettingsHelper {
         // Check file's existence
         bool fileExists = File.Exists(storagePath);
         if (!fileExists) {
-            // Wen don't throw an error since during OnEnable() all values will be initialized with 
-            // the system's default and create a new file once this class get's out of scope
+            // Wen don't throw an error since during OnEnable() all values
+            // will be initialized with the system's default and create a
+            // new file once this class get's out of scope
             Debug.LogFormat("No previous Yarn Spinner preferences have been found in {0}.", storagePath);
             OnReadError?.Invoke();
             return;
@@ -38,15 +40,18 @@ public static class YarnSettingsHelper {
     /// Creates a class from a JSON string representing it's state.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    /// <param name="settingsClass">The type of the class to be created.</param>
-    /// <param name="json">The state of the class to be created described as JSON formatted string.</param>
+    /// <param name="settingsClass">The type of the class to be
+    /// created.</param>
+    /// <param name="json">The state of the class to be created described
+    /// as JSON formatted string.</param>
     /// <param name="OnReadError">The action to call on an error.</param>
     public static void ReadJsonFromString<T>(T settingsClass, string json, Action OnReadError = null) {
         // Parse json to *this* ScriptableObject
         try {
             JsonUtility.FromJsonOverwrite(json, settingsClass);
         } catch (Exception) {
-            // No big deal since we'll initialize all values during OnEnable()
+            // No big deal since we'll initialize all values during
+            // OnEnable()
             Debug.Log("Error parsing Yarn Spinner preferences from JSON.");
             OnReadError?.Invoke();
             return;

--- a/Runtime/YarnTranslation.cs
+++ b/Runtime/YarnTranslation.cs
@@ -13,7 +13,8 @@ public class YarnTranslation
     }
 
     /// <summary>
-    /// Name of the language of this <see cref="YarnTranslation"/> in RFC 4646.
+    /// Name of the language of this <see cref="YarnTranslation"/> in RFC
+    /// 4646.
     /// </summary>
     public string languageName;
 

--- a/Samples~/Space/Space.unity
+++ b/Samples~/Space/Space.unity
@@ -1818,6 +1818,7 @@ PrefabInstance:
         type: 3}
       propertyPath: dialogueViews.Array.size
       value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 5935829475398715329, guid: 4ec3df5875e7347beb6176b545b8fb39,
         type: 3}
       propertyPath: onNodeStart.m_PersistentCalls.m_Calls.Array.size
@@ -1901,7 +1902,7 @@ PrefabInstance:
     - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
         type: 3}
       propertyPath: onLineFinishDisplaying.m_PersistentCalls.m_Calls.Array.size
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
         type: 3}
@@ -2005,8 +2006,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
         type: 3}
-      propertyPath: onLineFinishDisplaying.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
-      value: 1
+      propertyPath: onLineFinishDisplaying.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: onLineFinishDisplaying.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: onLineFinishDisplaying.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 5935829475522760372, guid: 4ec3df5875e7347beb6176b545b8fb39,
         type: 3}

--- a/Samples~/Voice Over/Voice Over.unity
+++ b/Samples~/Voice Over/Voice Over.unity
@@ -484,96 +484,6 @@ PrefabInstance:
       propertyPath: dialogueViews.Array.data[1]
       value: 
       objectReference: {fileID: 2086818859}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueEnd.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueStart.m_PersistentCalls.m_Calls.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onLineFinishDisplayingOnAllViews.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onLineFinishDisplaying.m_PersistentCalls.m_Calls.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueEnd.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueEnd.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueEnd.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1410838597}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueEnd.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: LoadSceneMenu
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueEnd.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueStart.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueStart.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onDialogueStart.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 2086818859}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onLineFinishDisplayingOnAllViews.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onLineFinishDisplayingOnAllViews.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onLineFinishDisplayingOnAllViews.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 2086818860}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onLineFinishDisplayingOnAllViews.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: SetActive
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onLineFinishDisplayingOnAllViews.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: onLineFinishDisplayingOnAllViews.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5935829475522760372, guid: 4ec3df5875e7347beb6176b545b8fb39,
         type: 3}
       propertyPath: m_AnchorMin.y
@@ -633,41 +543,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
         type: 3}
@@ -711,9 +586,3 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   fadeOutTimeOnLineFinish: 0.05
   audioSource: {fileID: 0}
---- !u!1 &2086818860 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 9020856951131138864, guid: 4ec3df5875e7347beb6176b545b8fb39,
-    type: 3}
-  m_PrefabInstance: {fileID: 2086818857}
-  m_PrefabAsset: {fileID: 0}

--- a/Tests/Runtime/DialogueRunnerMockUI.cs
+++ b/Tests/Runtime/DialogueRunnerMockUI.cs
@@ -25,7 +25,7 @@ public class DialogueRunnerMockUI : Yarn.Unity.DialogueViewBase
         onDismissalComplete();
     }
 
-    public override void OnLineStatusChanged(LocalizedLine dialogueLine, LineStatus previousStatus, LineStatus newStatus)
+    public override void OnLineStatusChanged(LocalizedLine dialogueLine)
     {
         // Do nothing in response to lines changing status
     }

--- a/Tests/Runtime/DialogueRunnerMockUI.cs
+++ b/Tests/Runtime/DialogueRunnerMockUI.cs
@@ -4,32 +4,29 @@ using Yarn.Unity;
 
 public class DialogueRunnerMockUI : Yarn.Unity.DialogueViewBase
 {
+    // The text of the most recently received line that we've been given
     public string CurrentLine { get; private set; } = default;
 
-    protected override IEnumerator RunLine(LocalizedLine dialogueLine)
+    public override void RunLine(LocalizedLine dialogueLine, Action onLineDeliveryComplete)
     {
+        // Store the localised text in our CurrentLine property and
+        // immediately signal that we're done "delivering" the line
         CurrentLine = dialogueLine.TextLocalized;
-        yield break;
+        onLineDeliveryComplete();
     }
 
     public override void RunOptions(DialogueOption[] dialogueOptions, Action<int> onOptionSelected)
     {
-        // Do nothing
+        // Do nothing in response to options becoming available
     }
 
-    protected override void FinishCurrentLine()
-    {
-        // Do nothing
+    public override void DismissLine(Action onDismissalComplete) {
+        // Immediately indicate that we're done 'dismissing' the line.
+        onDismissalComplete();
     }
 
-    protected override IEnumerator EndCurrentLine()
+    public override void OnLineStatusChanged(LocalizedLine dialogueLine, LineStatus previousStatus, LineStatus newStatus)
     {
-        // Do nothing
-        yield break;
-    }
-
-    protected override void OnFinishedLineOnAllViews()
-    {
-        // Do nothing
+        // Do nothing in response to lines changing status
     }
 }


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change
  (n/a; this PR is for an in-development feature)
* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [ ] Feature
- [x] Something else

* **What is the current behavior?** (You can also link to an open issue here)

Currently, dialogue views manage their own state individually, and the dialogue runner mediates among them all.

* **What is the new behavior (if this is a feature change)?**

This PR moves the ownership of a line's status to the line itself, rather than to individual views. This significantly simplifies the logic involved in managing the state of the line's delivery across multiple views, and almost entirely removes the need for synchronising multiple view's delivery status, since they now are entirely reactive to the line's state.

The idea behind this is now:

- When a line is ready to start being delivered, a LocalizedLine is created (the "line" hereafter), containing all of the prepared content that's needed to be delivered to the user.
- LocalizedLines have a Status variable, which is allowed to be any of the following:
  - Running
  - Interrupted
  - Delivered
  - Ended
- When a line is first created, its state is Running.

The life cycle of a line is this:

1. Each view is given the line, and a callback method to run when it's "done" (whatever that means for the view.) Each view is also added to a set of "active views", managed by the dialogue runner.
1. When the view finishes its delivery, it calls the callback method. This method removes that view from the set of active views. 
1. If the dialogue runner receives a signal to interrupt the line, the line's state is changed to Interrupted. All views are notified about this change, and should use it to speed up the delivery (again, in whatever way makes sense for each view) and call their "delivery complete" callback (that they received when it first received the line) ASAP.
1. When there's no more active views, the line's state changes to "Delivered".
1. After a line's state changes to "Delivered", the game may may choose to automatically change the line's state to "Ended", or choose to wait until the user signals that they're ready to move on (before setting the state to "Ended".) 
1. When  a line's state changes to "Ended", all lines are told to begin dismissing the line, and are given a callback method to invoke when they're done dismissing it. (This is intended to support views that need time to dismiss the line, like fading text off-screen.) When all views have called their "dismissal complete" callback, the line is now done, and the Dialogue object is ready to proceed to the next piece of content.

During this process, views get notified about changes in the line's state via the OnLineStatusChanged method. They can choose how they want to deal with the changes in state.

This means that we don't need to keep track of the "lowest status" across all views, since the line itself keeps track of its own state. The distinction between "user wants to interrupt" and "user wants to move to next line" is no longer needed, further simplifying the logic.

@Schroedingers-Cat, I'd like to get your eyes on this, since you wrote the original dialogue view state, and this is a pretty significant tweak to your original design. Let me know what you think! I've also updated the FMOD voiceover playback system, but it'd be good if you could verify it works.

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

This PR changes the architecture for dialogue views, but given that this is a newly merged feature in `develop`, expected impact in existing projects is very low.

* **Other information**:
