### PR TITLE
Fix up references to the test assembly in Unity 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Added an explicit reference to YarnSpinner.dll in YarnSpinnerTests.asmdef, fixing compiler issues in Unity 2019.3+
+
 ### Removed
 
 ## [v1.2.0] 2020-05-04

--- a/Tests/Runtime/YarnSpinnerTests.asmdef
+++ b/Tests/Runtime/YarnSpinnerTests.asmdef
@@ -10,7 +10,12 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
-    "precompiledReferences": [],
+    
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "YarnSpinner.dll"
+    ],
+    
     "autoReferenced": true,
     "defineConstraints": []
 }


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

Unity 2019.3 and later encounter compiler errors in the test source code, because the relevant assembly definition file doesn't reference YarnSpinner.dll.

* **What is the new behavior (if this is a feature change)?**

This PR fixes the issue.
* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking changes.

* **Other information**:

This is a bug-fix intended to be merged directly into master (rather than being applied to the v2.0 work being done in `develop`), so I'm opening it as a PR to more easily test it in the Unity Package Manager.