### PR TITLE
Bugfix/dialogue views nullcheck

### DIFF
--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -210,6 +210,8 @@ namespace Yarn.Unity
         {
             // Stop any processes that might be running already
             foreach (var dialogueView in dialogueViews) {
+                if (dialogueView == null) continue;
+
                 dialogueView.StopAllCoroutines();
             }
 
@@ -222,6 +224,8 @@ namespace Yarn.Unity
 
                 // Signal that we're starting up.
                 foreach (var dialogueView in dialogueViews) {
+                    if (dialogueView == null) continue;
+
                     dialogueView.DialogueStarted();
                 }
 
@@ -546,6 +550,12 @@ namespace Yarn.Unity
             // next line (or interrupt the current one).
             System.Action continueAction = OnViewUserIntentNextLine;
             foreach (var dialogueView in dialogueViews) {
+                if (dialogueView == null)
+                {
+                    Debug.LogWarning("The 'Dialogue Views' field contains a NULL element.", gameObject);
+                    continue;
+                }
+
                 dialogueView.onUserWantsLineContinuation = continueAction;
             }
 
@@ -733,6 +743,8 @@ namespace Yarn.Unity
                     };
                 }
                 foreach (var dialogueView in dialogueViews) {
+                    if (dialogueView == null) continue;
+
                     dialogueView.RunOptions(optionSet, selectAction);
                 }
             }
@@ -741,6 +753,8 @@ namespace Yarn.Unity
             {
                 IsDialogueRunning = false;
                 foreach (var dialogueView in dialogueViews) {
+                    if (dialogueView == null) continue;
+
                     dialogueView.DialogueComplete();
                 }
                 onDialogueComplete.Invoke();
@@ -827,6 +841,8 @@ namespace Yarn.Unity
 
                 // Send line to available dialogue views
                 foreach (var dialogueView in dialogueViews) {
+                    if (dialogueView == null) continue;
+
                     // Mark this dialogue view as active                
                     ActiveDialogueViews.Add(dialogueView);
                     dialogueView.RunLine(CurrentLine, 
@@ -1121,8 +1137,10 @@ namespace Yarn.Unity
             // Update the state of the line and let the views know.
             line.Status = newStatus;
 
-            foreach (var view in dialogueViews) {
-                view.OnLineStatusChanged(line);
+            foreach (var dialogueView in dialogueViews) {
+                if (dialogueView == null) continue;
+
+                dialogueView.OnLineStatusChanged(line);
             }
         }
 
@@ -1201,7 +1219,8 @@ namespace Yarn.Unity
         {
             ActiveDialogueViews.Clear();
 
-            foreach (var view in dialogueViews) {
+            foreach (var dialogueView in dialogueViews) {
+                if (dialogueView == null) continue;
                 // we do this in two passes - first by adding each
                 // dialogueView into ActiveDialogueViews, then by asking
                 // them to dismiss the line - because calling
@@ -1210,11 +1229,13 @@ namespace Yarn.Unity
                 // to zero active dialogue views, which means
                 // DialogueViewCompletedDismissal will mark the line as
                 // entirely done)
-                ActiveDialogueViews.Add(view);
+                ActiveDialogueViews.Add(dialogueView);
             }
                 
-            foreach (var view in dialogueViews) {
-                view.DismissLine(() => DialogueViewCompletedDismissal(view));
+            foreach (var dialogueView in dialogueViews) {
+                if (dialogueView == null) continue;
+
+                dialogueView.DismissLine(() => DialogueViewCompletedDismissal(dialogueView));
             }
         }
 

--- a/Tests/Runtime/DialogueRunnerTests.cs
+++ b/Tests/Runtime/DialogueRunnerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -22,6 +23,39 @@ namespace Yarn.Unity.Tests
 
             var runner = GameObject.FindObjectOfType<DialogueRunner>();
             DialogueRunnerMockUI dialogueUI = GameObject.FindObjectOfType<DialogueRunnerMockUI>();
+
+            runner.StartDialogue();
+            yield return null;
+
+            Assert.That(string.Equals(dialogueUI.CurrentLine, "Spieler: Kannst du mich hören?"));
+            dialogueUI.MarkLineComplete();
+
+            Assert.That(string.Equals(dialogueUI.CurrentLine, "NPC: Klar und deutlich."));
+            dialogueUI.MarkLineComplete();
+
+            Assert.AreEqual(2, dialogueUI.CurrentOptions.Count);
+            Assert.AreEqual("Mir reicht es.", dialogueUI.CurrentOptions[0]);
+            Assert.AreEqual("Nochmal!", dialogueUI.CurrentOptions[1]);
+        }
+
+        [UnityTest]
+        public IEnumerator HandleLine_OnViewsArrayContainingNullElement_SendCorrectLinesToUI()
+        {
+            SceneManager.LoadScene("DialogueRunnerTest");
+            bool loaded = false;
+            SceneManager.sceneLoaded += (index, mode) =>
+            {
+                loaded = true;
+            };
+            yield return new WaitUntil(() => loaded);
+
+            var runner = GameObject.FindObjectOfType<DialogueRunner>();
+            DialogueRunnerMockUI dialogueUI = GameObject.FindObjectOfType<DialogueRunnerMockUI>();
+
+            // Insert a null element into the dialogue views array
+            var viewArrayWithNullElement = runner.dialogueViews.ToList();
+            viewArrayWithNullElement.Add(null);
+            runner.dialogueViews = viewArrayWithNullElement.ToArray();
 
             runner.StartDialogue();
             yield return null;


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs do not have to be updated for this fix
- [ ] CHANGELOG.md does not have to be updated since the fix is for an unreleased change

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)
If the Dialogue Views array in the Runner contains one `None` element, the DialogueRunner will crash.

* **What is the new behavior (if this is a feature change)?**
The DialogueRunner now checks an element before accessing it. On Start(), the DialogueRunner will also print out a warning once.  

Additionally, this PR includes a test which adds a null element into the Dialogue View array. With the fix of this PR, this test succeeds. Without the fix, the test fails.


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Additional Info**
This PR also makes all foreach()-loops over the DialogueViews array use the same local variable name.