### PR TITLE
Clear() should clear strings dictionary as well

### DIFF
--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -35,7 +35,6 @@ using System;
 
 namespace Yarn.Unity
 {
-
     /// <summary>
     /// The [DialogueRunner]({{|ref
     /// "/docs/unity/components/dialogue-runner.md"|}}) component acts as
@@ -49,8 +48,6 @@ namespace Yarn.Unity
         /// scene start.
         /// </summary>
         public YarnProgram[] yarnScripts;
-
-         
 
         /// <summary>
         /// The language code used to select a string table.
@@ -275,6 +272,7 @@ namespace Yarn.Unity
         public void Clear()
         {
             Assert.IsFalse(IsDialogueRunning, "You cannot clear the dialogue system while a dialogue is running.");
+            strings.Clear();
             Dialogue.UnloadAll();
         }
 


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

DialogueRunner.Clear() will does not clear the strings Dictionary

* **What is the new behavior (if this is a feature change)?**

DialogueRunner.Clear() will now clear the strings Dictionary

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:

