### PR TITLE
InMemoryVariableStorage redesign + serialization + example save/load functions

### DIFF
--- a/Editor/InMemoryVariableStorageEditor.cs
+++ b/Editor/InMemoryVariableStorageEditor.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using Yarn.Unity;
+
+[CustomEditor(typeof(InMemoryVariableStorage))]
+public class InMemoryVariableStorageEditor : Editor 
+{
+    public override void OnInspectorGUI()
+    {
+        base.OnInspectorGUI();
+        var varStorage = (InMemoryVariableStorage)target;
+        
+        varStorage.showDebug = EditorGUILayout.Foldout(varStorage.showDebug, "Debug Variables");
+
+        if ( !varStorage.showDebug ) {
+            return;
+        }
+
+        if ( !Application.isPlaying ) {
+            EditorGUILayout.HelpBox("Not in Play Mode, so no variables to display!", MessageType.Info);
+            return;
+        }
+
+        var style = EditorGUIUtility.GetBuiltinSkin( EditorSkin.Inspector ).label;
+        var list = varStorage.GetDebugList();
+        var height = style.CalcHeight( new GUIContent(list), EditorGUIUtility.currentViewWidth ) - 5;
+        EditorGUILayout.SelectableLabel( list, GUILayout.MaxHeight(height), GUILayout.ExpandHeight(true) );
+        
+    }
+}

--- a/Editor/InMemoryVariableStorageEditor.cs
+++ b/Editor/InMemoryVariableStorageEditor.cs
@@ -2,31 +2,35 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
-using Yarn.Unity;
 
-[CustomEditor(typeof(InMemoryVariableStorage))]
-public class InMemoryVariableStorageEditor : Editor 
+namespace Yarn.Unity
 {
-    public override void OnInspectorGUI()
+
+    [CustomEditor(typeof(InMemoryVariableStorage))]
+    public class InMemoryVariableStorageEditor : Editor 
     {
-        base.OnInspectorGUI();
-        var varStorage = (InMemoryVariableStorage)target;
-        
-        varStorage.showDebug = EditorGUILayout.Foldout(varStorage.showDebug, "Debug Variables");
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+            var varStorage = (InMemoryVariableStorage)target;
+            
+            varStorage.showDebug = EditorGUILayout.Foldout(varStorage.showDebug, "Debug Variables");
 
-        if ( !varStorage.showDebug ) {
-            return;
+            if ( !varStorage.showDebug ) {
+                return;
+            }
+
+            if ( !Application.isPlaying ) {
+                EditorGUILayout.HelpBox("Not in Play Mode, so no variables to display!", MessageType.Info);
+                return;
+            }
+
+            var style = EditorGUIUtility.GetBuiltinSkin( EditorSkin.Inspector ).label;
+            var list = varStorage.GetDebugList();
+            var height = style.CalcHeight( new GUIContent(list), EditorGUIUtility.currentViewWidth ) - 5;
+            EditorGUILayout.SelectableLabel( list, GUILayout.MaxHeight(height), GUILayout.ExpandHeight(true) );
+            
         }
-
-        if ( !Application.isPlaying ) {
-            EditorGUILayout.HelpBox("Not in Play Mode, so no variables to display!", MessageType.Info);
-            return;
-        }
-
-        var style = EditorGUIUtility.GetBuiltinSkin( EditorSkin.Inspector ).label;
-        var list = varStorage.GetDebugList();
-        var height = style.CalcHeight( new GUIContent(list), EditorGUIUtility.currentViewWidth ) - 5;
-        EditorGUILayout.SelectableLabel( list, GUILayout.MaxHeight(height), GUILayout.ExpandHeight(true) );
-        
     }
+
 }

--- a/Editor/InMemoryVariableStorageEditor.cs
+++ b/Editor/InMemoryVariableStorageEditor.cs
@@ -25,9 +25,9 @@ namespace Yarn.Unity
                 return;
             }
 
-            var style = EditorGUIUtility.GetBuiltinSkin( EditorSkin.Inspector ).label;
+            var style = EditorStyles.label;
             var list = varStorage.GetDebugList();
-            var height = style.CalcHeight( new GUIContent(list), EditorGUIUtility.currentViewWidth ) - 5;
+            var height = style.CalcHeight( new GUIContent(list), EditorGUIUtility.currentViewWidth );
             EditorGUILayout.SelectableLabel( list, GUILayout.MaxHeight(height), GUILayout.ExpandHeight(true) );
             
         }

--- a/Editor/InMemoryVariableStorageEditor.cs.meta
+++ b/Editor/InMemoryVariableStorageEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 230a34f0c8ffc4b45b5f098c65d69492
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/InMemoryVariableStorage.cs
+++ b/Runtime/InMemoryVariableStorage.cs
@@ -32,31 +32,30 @@ using Yarn.Unity;
 namespace Yarn.Unity {
 
     /// <summary>
-    /// An simple implementation of DialogueUnityVariableStorage, which
-    /// stores everything in memory.
+    /// A simple implementation of VariableStorageBehaviour.
     /// </summary>
     /// <remarks>
-    /// This class does not perform any saving or loading on its own, but
-    /// you can enumerate over the variables by using a `foreach` loop:
+    /// As of v2.0, this class has basic serialization and save/load example functions.
+    /// You can also enumerate over the variables by using a `foreach` loop:
     /// 
     /// <![CDATA[
     /// ```csharp    
     /// // 'storage' is an InMemoryVariableStorage    
     /// foreach (var variable in storage) {
     ///         string name = variable.Key;
-    ///         Yarn.Value value = variable.Value;
+    ///         System.Object value = variable.Value;
     /// }   
     /// ```
     /// ]]>
     /// 
+    /// Note that as of v2.0, this class no longer uses Yarn.Value, to
+    /// enforce static typing of variables within the Yarn Program.
     /// </remarks>    
     public class InMemoryVariableStorage : VariableStorageBehaviour, IEnumerable<KeyValuePair<string, object>>
     {
-
-        /// Where we actually keeping our variables
-        [System.Serializable] class StringDictionary : SerializedDictionary<string, string> {} // serializable dictionary workaround
+        /// Where we're actually keeping our variables
         private Dictionary<string, object> variables = new Dictionary<string, object>();
-        private Dictionary<string, System.Type> variableTypes = new Dictionary<string, System.Type>();
+        private Dictionary<string, System.Type> variableTypes = new Dictionary<string, System.Type>(); // needed for serialization
 
         /// <summary>
         /// A default value to apply when the object wakes up, or when
@@ -230,9 +229,11 @@ namespace Yarn.Unity {
         }
 
         #endregion
-        
+
 
         #region Save/Load
+
+        [System.Serializable] class StringDictionary : SerializedDictionary<string, string> {} // serializable dictionary workaround
 
         static string[] SEPARATOR = new string[] { "/" }; // used for serialization
 

--- a/Runtime/InMemoryVariableStorage.cs
+++ b/Runtime/InMemoryVariableStorage.cs
@@ -86,6 +86,9 @@ namespace Yarn.Unity {
 
         #region Setters
 
+        /// <summary>
+        /// Used internally by serialization functions to wrap around the SetValue() methods.
+        /// </summary>
         void SetVariable(string name, Yarn.Type type, string value) {
             switch (type)
             {
@@ -141,7 +144,7 @@ namespace Yarn.Unity {
         /// Retrieves a <see cref="Value"/> by name.
         /// </summary>
         /// <param name="variableName">The name of the variable to retrieve
-        /// the value of.</param>
+        /// the value of. Don't forget to include the "$" at the beginning!</param>
         /// <returns>The <see cref="Value"/>. If a variable by the name of
         /// <paramref name="variableName"/> is not present, returns a value
         /// representing `null`.</returns>
@@ -206,7 +209,7 @@ namespace Yarn.Unity {
         /// Import a JSON string into variable storage, like when loading save game data.
         /// </summary>
         public void DeserializeAllVariablesFromJSON(string jsonData) {
-            Debug.Log(jsonData);
+            // Debug.Log(jsonData);
             var serializedVariables = JsonUtility.FromJson<StringDictionary>( jsonData );
             foreach ( var variable in serializedVariables ) {
                 var serializedKey = variable.Key.Split(SEPARATOR, 2, System.StringSplitOptions.None);
@@ -217,17 +220,25 @@ namespace Yarn.Unity {
             }
         }
 
-        const string PLAYER_PREFS_KEY = "YarnVariableStorage";
+        const string DEFAULT_PLAYER_PREFS_KEY = "DefaultYarnVariableStorage";
 
         /// <summary>
-        /// Serialize all variables to JSON, then save data to Unity's built-in PlayerPrefs with playerPrefsKey.
+        /// Serialize all variables to JSON, then save data to Unity's built-in PlayerPrefs with default playerPrefsKey.
         /// </summary>
         public void SaveToPlayerPrefs() {
-            var saveData = SerializeAllVariablesToJSON();
-            PlayerPrefs.SetString(PLAYER_PREFS_KEY, saveData);
-            PlayerPrefs.Save();
-            Debug.Log("Variables saved to PlayerPrefs.");
+            SaveToPlayerPrefs( DEFAULT_PLAYER_PREFS_KEY );
         }
+
+        /// <summary>
+        /// Serialize all variables to JSON, then save data to Unity's built-in PlayerPrefs under playerPrefsKey parameter.
+        /// </summary>
+        public void SaveToPlayerPrefs(string playerPrefsKey) {
+            var saveData = SerializeAllVariablesToJSON();
+            PlayerPrefs.SetString(playerPrefsKey, saveData);
+            PlayerPrefs.Save();
+            Debug.Log($"Variables saved to PlayerPrefs with key {playerPrefsKey}");
+        }
+
 
         /// <summary>
         /// Serialize all variables to JSON, then write the data to a file.
@@ -235,18 +246,26 @@ namespace Yarn.Unity {
         public void SaveToFile(string filepath) {
             var saveData = SerializeAllVariablesToJSON();
             System.IO.File.WriteAllText(filepath, saveData, System.Text.Encoding.UTF8);
+            Debug.Log($"Variables saved to file {filepath}");
         }
 
         /// <summary>
-        /// Load JSON data from Unity's built-in PlayerPrefs with playerPrefsKey, and deserialize as variables.
+        /// Load JSON data from Unity's built-in PlayerPrefs with default playerPrefsKey, and deserialize as variables.
         /// </summary>
         public void LoadFromPlayerPrefs() {
-            if ( PlayerPrefs.HasKey(PLAYER_PREFS_KEY)) {
-                var saveData = PlayerPrefs.GetString(PLAYER_PREFS_KEY);
+            LoadFromPlayerPrefs( DEFAULT_PLAYER_PREFS_KEY );
+        }
+
+        /// <summary>
+        /// Load JSON data from Unity's built-in PlayerPrefs with defined playerPrefsKey parameter, and deserialize as variables.
+        /// </summary>
+        public void LoadFromPlayerPrefs(string playerPrefsKey) {
+            if ( PlayerPrefs.HasKey(playerPrefsKey)) {
+                var saveData = PlayerPrefs.GetString(playerPrefsKey);
                 DeserializeAllVariablesFromJSON(saveData);
-                Debug.Log("Variables loaded from PlayerPrefs.");
+                Debug.Log($"Variables loaded from PlayerPrefs under key {playerPrefsKey}");
             } else {
-                Debug.LogWarning($"No PlayerPrefs key {PLAYER_PREFS_KEY} found, so no variables loaded.");
+                Debug.LogWarning($"No PlayerPrefs key {playerPrefsKey} found, so no variables loaded.");
             }
         }
 
@@ -256,6 +275,7 @@ namespace Yarn.Unity {
         public void LoadFromFile(string filepath) {
             var saveData = System.IO.File.ReadAllText(filepath, System.Text.Encoding.UTF8);
             DeserializeAllVariablesFromJSON(saveData);
+            Debug.Log($"Variables loaded from file {filepath}");
         }
 
         public static readonly Dictionary<System.Type, Yarn.Type> TypeMappings = new Dictionary<System.Type, Yarn.Type>

--- a/Runtime/InMemoryVariableStorage.cs
+++ b/Runtime/InMemoryVariableStorage.cs
@@ -49,7 +49,7 @@ namespace Yarn.Unity {
     /// ]]>
     /// 
     /// Note that as of v2.0, this class no longer uses Yarn.Value, to
-    /// enforce static typing of variables within the Yarn Program.
+    /// enforce static typing of declared variables within the Yarn Program.
     /// </remarks>    
     public class InMemoryVariableStorage : VariableStorageBehaviour, IEnumerable<KeyValuePair<string, object>>
     {
@@ -57,55 +57,11 @@ namespace Yarn.Unity {
         private Dictionary<string, object> variables = new Dictionary<string, object>();
         private Dictionary<string, System.Type> variableTypes = new Dictionary<string, System.Type>(); // needed for serialization
 
-        /// <summary>
-        /// A default value to apply when the object wakes up, or when
-        /// ResetToDefaults is called.
-        /// </summary>
-        [System.Serializable]
-        public class DefaultVariable
-        {
-            /// <summary>
-            /// The name of the variable.
-            /// </summary>
-            /// <remarks>
-            /// Do not include the `$` prefix in front of the variable
-            /// name. It will be added for you.
-            /// </remarks>
-            [Tooltip("don't include the $ prefix")] public string name;
-
-            /// <summary>
-            /// The value of the variable, as a string.
-            /// </summary>
-            /// <remarks>
-            /// This string will be converted to the appropriate type,
-            /// depending on the value of <see cref="type"/>.
-            /// </remarks>
-            public string value;
-
-            /// <summary>
-            /// The type of the variable.
-            /// </summary>
-            public Yarn.Type type;
-        }
-
-        /// <summary>
-        /// The list of default variables that should be present in the
-        /// InMemoryVariableStorage when the scene loads.
-        /// </summary>
-        [Tooltip("use DefaultVariables to override the default values of Yarn variables")] public DefaultVariable[] defaultVariables;
-        public bool setDefaultVariablesOnStart = true;
-
         [Header("Optional debugging tools")]
         
-        /// A UI.Text that can show the current list of all variables. Optional.
+        /// A UI.Text that can show the current list of all variables in-game. Optional.
         [SerializeField] 
         internal UnityEngine.UI.Text debugTextView = null;
-
-        internal void Start () {
-            if ( setDefaultVariablesOnStart ) {
-                SetDefaultVariables();
-            }
-        }
 
         /// If we have a debug view, show the list of all variables in it
         internal void Update ()
@@ -124,12 +80,6 @@ namespace Yarn.Unity {
 
 
         #region Setters
-
-        public void SetDefaultVariables () {
-            foreach ( var defaultVar in defaultVariables ) {
-                SetVariable( defaultVar.name, defaultVar.type, defaultVar.value );
-            }
-        }
 
         void SetVariable(string name, Yarn.Type type, string value) {
             switch (type)
@@ -219,13 +169,6 @@ namespace Yarn.Unity {
         {
             variables.Clear();
             variableTypes.Clear();
-        }
-
-        public void ResetToDefaults ()
-        {
-            variables.Clear ();
-            variableTypes.Clear();
-            SetDefaultVariables();
         }
 
         #endregion

--- a/Runtime/InMemoryVariableStorage.cs
+++ b/Runtime/InMemoryVariableStorage.cs
@@ -58,24 +58,29 @@ namespace Yarn.Unity {
         private Dictionary<string, System.Type> variableTypes = new Dictionary<string, System.Type>(); // needed for serialization
 
         [Header("Optional debugging tools")]
-        
+        [HideInInspector] public bool showDebug;
         /// A UI.Text that can show the current list of all variables in-game. Optional.
-        [SerializeField] 
+        [SerializeField, Tooltip("(optional) output list of variables and values to Text UI in-game")] 
         internal UnityEngine.UI.Text debugTextView = null;
 
         /// If we have a debug view, show the list of all variables in it
         internal void Update ()
         {
             if (debugTextView != null) {
-                var stringBuilder = new System.Text.StringBuilder ();
-                foreach (KeyValuePair<string,object> item in variables) {
-                    stringBuilder.AppendLine (string.Format ("{0} = {1}",
-                                                            item.Key,
-                                                            item.Value.ToString()));
-                }
-                debugTextView.text = stringBuilder.ToString ();
+                debugTextView.text = GetDebugList();
                 debugTextView.SetAllDirty();
             }
+        }
+
+        public string GetDebugList() {
+            var stringBuilder = new System.Text.StringBuilder ();
+            foreach (KeyValuePair<string,object> item in variables) {
+                stringBuilder.AppendLine (string.Format ("{0} = {1} ({2})",
+                                                        item.Key,
+                                                        item.Value.ToString(),
+                                                        variableTypes[item.Key].ToString().Substring("System.".Length) )); 
+            }
+            return stringBuilder.ToString();
         }
 
 

--- a/Runtime/InMemoryVariableStorage.cs
+++ b/Runtime/InMemoryVariableStorage.cs
@@ -198,7 +198,7 @@ namespace Yarn.Unity {
                 serializableVariables.Add( jsonKey, jsonValue.ToString() );
             }
             var saveData = JsonUtility.ToJson(serializableVariables, prettyPrint);
-            Debug.Log(saveData);
+            // Debug.Log(saveData);
             return saveData;
         }
 

--- a/Tests/Runtime/Tests.yarnprogram.meta
+++ b/Tests/Runtime/Tests.yarnprogram.meta
@@ -4,7 +4,6 @@ ScriptedImporter:
   fileIDToRecycleName:
     4900000: Strings
     11400000: Program
-    2186277476908879412: ImportLogs
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Tests/Runtime/VariableStorageTestProgram.yarnprogram
+++ b/Tests/Runtime/VariableStorageTestProgram.yarnprogram
@@ -1,0 +1,5 @@
+﻿title: Program
+tags:
+---
+
+===

--- a/Tests/Runtime/VariableStorageTestProgram.yarnprogram.meta
+++ b/Tests/Runtime/VariableStorageTestProgram.yarnprogram.meta
@@ -1,19 +1,36 @@
 fileFormatVersion: 2
 guid: 43f86f87a9e6d454799e66e58df0d6d3
 ScriptedImporter:
-  internalIDToNameTable: []
+  fileIDToRecycleName:
+    4900000: Strings
+    11400000: Program
   externalObjects: {}
-  serializedVersion: 2
   userData: 
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 053561912b1654d80a424bb0696a74ae, type: 3}
   sourceScripts:
-  - {fileID: 6391573757903218779, guid: 377c177f64f109d46a63aa758c778012, type: 3}
-  compileError: 'Error in Assets/Scenes/TestScript.yarn line 7
-
-    <<set $yarnVar
-    to "hello">>
-
-    Undeclared variable $yarnVar'
-  serializedDeclarations: []
+  - {fileID: 4900000, guid: 377c177f64f109d46a63aa758c778012, type: 3}
+  compileError: 
+  serializedDeclarations:
+  - name: $stringVar
+    type: 2
+    defaultValueBool: 0
+    defaultValueNumber: 0
+    defaultValueString: hello
+    description: 
+    sourceYarnAsset: {fileID: 4900000, guid: 377c177f64f109d46a63aa758c778012, type: 3}
+  - name: $boolVar
+    type: 3
+    defaultValueBool: 0
+    defaultValueNumber: 0
+    defaultValueString: 
+    description: 
+    sourceYarnAsset: {fileID: 4900000, guid: 377c177f64f109d46a63aa758c778012, type: 3}
+  - name: $floatVar
+    type: 1
+    defaultValueBool: 0
+    defaultValueNumber: 420.1
+    defaultValueString: 
+    description: 
+    sourceYarnAsset: {fileID: 4900000, guid: 377c177f64f109d46a63aa758c778012, type: 3}

--- a/Tests/Runtime/VariableStorageTestProgram.yarnprogram.meta
+++ b/Tests/Runtime/VariableStorageTestProgram.yarnprogram.meta
@@ -1,0 +1,19 @@
+fileFormatVersion: 2
+guid: 43f86f87a9e6d454799e66e58df0d6d3
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 053561912b1654d80a424bb0696a74ae, type: 3}
+  sourceScripts:
+  - {fileID: 6391573757903218779, guid: 377c177f64f109d46a63aa758c778012, type: 3}
+  compileError: 'Error in Assets/Scenes/TestScript.yarn line 7
+
+    <<set $yarnVar
+    to "hello">>
+
+    Undeclared variable $yarnVar'
+  serializedDeclarations: []

--- a/Tests/Runtime/VariableStorageTestScript.yarn
+++ b/Tests/Runtime/VariableStorageTestScript.yarn
@@ -1,0 +1,14 @@
+﻿title: Start
+tags:
+---
+<<declare $stringVar = "hello">>
+<<declare $boolVar = false>>
+<<declare $floatVar = 420.1>>
+Variables have been declared.#line:03d22b8
+
+<<set $stringVar = "hola">>
+<<set $boolVar = true>>
+<<set $floatVar = 1.420>>
+Variables have now been set.#line:0de8b02
+
+===

--- a/Tests/Runtime/VariableStorageTestScript.yarn.meta
+++ b/Tests/Runtime/VariableStorageTestScript.yarn.meta
@@ -1,0 +1,18 @@
+fileFormatVersion: 2
+guid: 377c177f64f109d46a63aa758c778012
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 94073015eacc34c1d8fc6786e43d60ca, type: 3}
+  baseLanguageID: en
+  stringIDs: []
+  AnyImplicitStringIDs: 0
+  isSuccesfullyParsed: 1
+  parseErrorMessage: 
+  baseLanguage: {instanceID: 0}
+  localizations: []
+  localizationDatabase: {instanceID: 0}

--- a/Tests/Runtime/VariableStorageTestScript.yarn.meta
+++ b/Tests/Runtime/VariableStorageTestScript.yarn.meta
@@ -1,15 +1,18 @@
 fileFormatVersion: 2
 guid: 377c177f64f109d46a63aa758c778012
 ScriptedImporter:
-  internalIDToNameTable: []
+  fileIDToRecycleName:
+    4900000: Program
+    4900002: Strings
   externalObjects: {}
-  serializedVersion: 2
   userData: 
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 94073015eacc34c1d8fc6786e43d60ca, type: 3}
   baseLanguageID: en
-  stringIDs: []
+  stringIDs:
+  - line:03d22b8
+  - line:0de8b02
   AnyImplicitStringIDs: 0
   isSuccesfullyParsed: 1
   parseErrorMessage: 

--- a/Tests/Runtime/VariableStorageTests.cs
+++ b/Tests/Runtime/VariableStorageTests.cs
@@ -1,0 +1,148 @@
+﻿using System.Collections;
+using System.Linq;
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+using Yarn.Unity;
+
+namespace Yarn.Unity.Tests
+{
+    public class VariableStorageTests : IPrebuildSetup, IPostBuildCleanup
+    {
+        public void Setup()
+        {
+            RuntimeTestUtility.AddSceneToBuild(VariableStorageTestsSceneGUID);
+        }
+
+        public void Cleanup()
+        {
+            RuntimeTestUtility.RemoveSceneFromBuild(VariableStorageTestsSceneGUID);
+        }
+
+        const string VariableStorageTestsSceneGUID = "5b5f09716ba7bce4a8d2f115ea6083d3"; 
+
+        // Getters for the various components in the scene that we're
+        // working with
+        DialogueRunner Runner => GameObject.FindObjectOfType<DialogueRunner>();
+        DialogueUI UI => GameObject.FindObjectOfType<DialogueUI>();
+        InMemoryVariableStorage VarStorage => GameObject.FindObjectOfType<InMemoryVariableStorage>();
+        Text TextCanvas => UI.dialogueContainer.transform.GetComponentsInChildren<Text>()
+                                                         .First(element => element.gameObject.name == "Text");
+
+        [UnitySetUp]
+        public IEnumerator SetUp()
+        {
+            SceneManager.LoadScene("VariableStorageTests");
+            bool loaded = false;
+            SceneManager.sceneLoaded += (index, mode) =>
+            {
+                loaded = true;
+            };
+            yield return new WaitUntil(() => loaded);
+        }
+
+
+        const string stringTest = "Testing string variable.";
+        const bool boolTest = true;
+        const float floatTest = 4.20f;
+
+        [UnityTest]
+        public IEnumerator SetValue_TryGetValue()
+        {
+            // run all lines
+            Runner.StartDialogue();
+            UI.MarkLineComplete();
+            yield return null;
+            yield return null;
+            UI.MarkLineComplete();
+            yield return null;
+            yield return null;
+
+            // set, then get, then test equality
+            VarStorage.SetValue("$stringVar", stringTest);
+            VarStorage.TryGetValue<string>("$stringVar", out var actualStringResult);
+            Assert.AreEqual(stringTest, actualStringResult);
+
+            VarStorage.SetValue("$boolVar", boolTest);
+            VarStorage.TryGetValue<bool>("$boolVar", out var actualBoolResult);
+            Assert.AreEqual(boolTest, actualBoolResult);
+
+            VarStorage.SetValue("$floatVar", floatTest);
+            VarStorage.TryGetValue<float>("$floatVar", out var actualFloatResult);
+            Assert.AreEqual(floatTest, actualFloatResult);
+
+            VarStorage.SetValue("$totallyNewUndeclaredVar", stringTest);
+            VarStorage.TryGetValue<string>("$totallyNewUndeclaredVar", out var actualUndeclaredResult);
+            Assert.AreEqual(stringTest, actualUndeclaredResult);
+
+            yield return null;
+        }
+
+        void TestClearVarStorage() {
+            VarStorage.Clear();
+            int varCount = 0;
+            foreach ( var variable in VarStorage ) {
+                varCount++;
+            }
+            Assert.AreEqual(0,varCount);
+        }
+
+        void TestVariableValuesFromYarnScript() {
+            VarStorage.TryGetValue<string>("$stringVar", out var actualStringResult);
+            Assert.AreEqual("hola", actualStringResult);
+            VarStorage.TryGetValue<bool>("$boolVar", out var actualBoolResult);
+            Assert.AreEqual(true, actualBoolResult);
+            VarStorage.TryGetValue<float>("$floatVar", out var actualFloatResult);
+            Assert.AreEqual(1.420f, actualFloatResult);
+        }
+
+        const string testPlayerPrefsKey = "TemporaryPlayerPrefsYarnTestKey";
+        [UnityTest]
+        public IEnumerator SaveLoadPlayerPrefs()
+        {
+            // run all lines
+            Runner.StartDialogue();
+            UI.MarkLineComplete();
+            yield return null;
+            yield return null;
+            UI.MarkLineComplete();
+            yield return null;
+            yield return null;
+
+            // save all variable values to Player Prefs, clear, then load from Player Prefs
+            VarStorage.SaveToPlayerPrefs( testPlayerPrefsKey );
+            TestClearVarStorage();
+            VarStorage.LoadFromPlayerPrefs( testPlayerPrefsKey );
+            TestVariableValuesFromYarnScript();
+
+            // cleanup
+            PlayerPrefs.DeleteKey( testPlayerPrefsKey );
+        }
+
+        string testFilePath { get { return Application.persistentDataPath + Path.DirectorySeparatorChar + "YarnVariableStorageTest.json" ;} }
+        [UnityTest]
+        public IEnumerator SaveLoadFile()
+        {
+            // run all lines
+            Runner.StartDialogue();
+            UI.MarkLineComplete();
+            yield return null;
+            yield return null;
+            UI.MarkLineComplete();
+            yield return null;
+            yield return null;
+
+            // save all variable values to a file, clear, then load from a file
+            VarStorage.SaveToFile( testFilePath );
+            TestClearVarStorage();
+            VarStorage.LoadFromFile( testFilePath );
+            TestVariableValuesFromYarnScript();
+
+            // cleanup
+            File.Delete( testFilePath );
+        }
+    }
+}

--- a/Tests/Runtime/VariableStorageTests.cs.meta
+++ b/Tests/Runtime/VariableStorageTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09decd25e80b380428a43523c7e5458e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/VariableStorageTests.unity
+++ b/Tests/Runtime/VariableStorageTests.unity
@@ -293,7 +293,7 @@ PrefabInstance:
         type: 3}
       propertyPath: yarnProgram
       value: 
-      objectReference: {fileID: 2480198943629176163, guid: 43f86f87a9e6d454799e66e58df0d6d3,
+      objectReference: {fileID: 11400000, guid: 43f86f87a9e6d454799e66e58df0d6d3,
         type: 3}
     - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
         type: 3}

--- a/Tests/Runtime/VariableStorageTests.unity
+++ b/Tests/Runtime/VariableStorageTests.unity
@@ -1,0 +1,419 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &1454251653
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4068380849537614946, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_Name
+      value: Dialogue
+      objectReference: {fileID: 0}
+    - target: {fileID: 4068380849537614946, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474028046605, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474028046605, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474028046605, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474028046605, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474028046605, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474028046605, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474060538304, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474060538304, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474060538304, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474060538304, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474060538304, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474060538304, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474853694786, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474853694786, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474853694786, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474853694786, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474853694786, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474853694786, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829474855343396, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475171564543, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475171564543, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475171564543, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475171564543, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475171564543, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475171564543, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475398715329, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: yarnScripts.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475398715329, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: yarnScripts.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 40a60c3c28a91d34bbf2088bb0d2824a,
+        type: 3}
+    - target: {fileID: 5935829475398715329, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: startAutomatically
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475398715329, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: startNode
+      value: Start
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475398715329, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475398715329, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: yarnProgram
+      value: 
+      objectReference: {fileID: 2480198943629176163, guid: 43f86f87a9e6d454799e66e58df0d6d3,
+        type: 3}
+    - target: {fileID: 5935829475398715334, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: textSpeed
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475522760372, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475522760372, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475522760372, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475522760372, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475522760372, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5935829475522760372, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644669280371853063, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644669280371853063, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644669280371853063, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644669280371853063, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644669280371853063, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7644669280371853063, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245181055515182852, guid: 4ec3df5875e7347beb6176b545b8fb39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4ec3df5875e7347beb6176b545b8fb39, type: 3}

--- a/Tests/Runtime/VariableStorageTests.unity.meta
+++ b/Tests/Runtime/VariableStorageTests.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5b5f09716ba7bce4a8d2f115ea6083d3
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

DefaultVariables (initial variable value override via Unity inspector) was broken for v2.0

Since Yarn.Value is now internal only, it might be difficult for users to understand how to serialize variables stored as System.Object

* **What is the new behavior (if this is a feature change)?**

~~DefaultVariables behavior restored, along with configurable "ResetToDefaultOnStart" bool (default: true) to help surface what DefaultVariables actually is -- which imo is useful for playtesting?~~ seems DefaultVariables functionality has been basically moved to the YarnProgram asset inspector, and it's unclear how this interacts with v2.0 variable declarations? so maybe it really should be removed from InMemoryVariableStorage now?

Variables can now be serialized via JsonUtility, with example functions for saving to PlayerPrefs or writing to a file

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

While we're talking about types, should there be a Yarn.Type.Float and a Yarn.Type.Int, vs the existing Yarn.Type.Number?

* **Other information**:

Draft status for now, still have to test with an actual Yarn test script that sets / gets variables

In the future, if https://github.com/YarnSpinnerTool/YarnSpinner/pull/242 get finished, it'd be cool to pull the Save/Load functions out into a separate SaveManager.cs script that shows how to save and load both VM state + Variable Storage at the same time