### PR TITLE
fix Old options stay visible + minor VN sample fixes

### DIFF
--- a/Runtime/Views/DialogueUI.cs
+++ b/Runtime/Views/DialogueUI.cs
@@ -446,6 +446,11 @@ namespace Yarn.Unity {
                 i++;
             }
 
+            // hide all remaining unused buttons
+            for ( ; i < optionButtons.Count; i++) {
+                optionButtons[i].gameObject.SetActive(false);
+            }
+
             onOptionsStart?.Invoke();
 
             // Wait until the chooser has been used and then removed 

--- a/Samples~/VisualNovel/Visual Novel.unity
+++ b/Samples~/VisualNovel/Visual Novel.unity
@@ -367,6 +367,11 @@ PrefabInstance:
       propertyPath: onNameNotPresent.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6885618662069859611, guid: 9e0841b82a4ebcd438730d23886e17e6,
+        type: 3}
+      propertyPath: showCharacterName
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9e0841b82a4ebcd438730d23886e17e6, type: 3}
 --- !u!1 &484263811 stripped

--- a/Samples~/VisualNovel/VisualNovel_Readme.md
+++ b/Samples~/VisualNovel/VisualNovel_Readme.md
@@ -1,9 +1,6 @@
 # Visual Novel example documentation
 
-This is an example project that implements a few Yarn Spinner features:
-
-- `DialogueUISplit.cs` shows how to separate the speaker's name from their dialogue, and how to display them separately
-- `VNManager.cs` demos extensive use of Yarn Commands to implement custom visual novel functionality (sprite management, sound playback, screen fades)
+This is an example project that uses many custom Yarn Commands to implement custom visual novel functionality (sprite management, sound playback, screen fades). Look in `VNManager.cs` to see how!
 
 This is intended as an example of how Yarn Spinner is flexible enough to support a variety of game formats and genres. **It is not actively developed, it is just a template / example.** If you want to add new commands of functionality, try to figure it out yourself!
 
@@ -24,7 +21,7 @@ For reference, the example character sprites are about 600 x 1200 pixels. Becaus
 
 # VN Commands API reference
 
-If you're new to Yarn Spinner, read about [Yarn Commands](https://yarnspinner.dev/docs/unity/adding-command-handlers/).
+If you're new to Yarn Spinner, read about [Yarn Commands](https://yarnspinner.dev/docs/unity/working-with-commands/).
 
 API example: for the command `<<Draw (spriteName), (x=0.5), (y=0.5)>>`, the `"=0.5"` is a default value used if you don't specify the number yourself. So you can type `<<Draw house01>>` or `<<Draw DogHappy, 0.75>>` and it's ok, it will fill in the other parameters with default values.
 


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

issue #63

* **What is the new behavior (if this is a feature change)?**

added for() in DialogueUI.cs to hide all remaining buttons after the foreach() ... I suspect this bug was accidentally introduced for the new "invalid options" feature in v2.0.0-beta2

also slipped in some minor fixes of VN sample while I was in there (don't show character names + VisualNovel_Readme.md edits)

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

hopefully fixes things, if anything!!

* **Other information**:

should maybe rush this as a hotfix on the tag or branch, since the bug is simple but would likely break a lot of things for people