### PR TITLE
added ▸ button to preview AudioClips in Localization inspector

### DIFF
--- a/Editor/LocalizationEditor.cs
+++ b/Editor/LocalizationEditor.cs
@@ -14,10 +14,12 @@ public class LocalizationEditor : Editor {
 
     private SerializedProperty languageNameProperty;
     private SerializedProperty assetSourceFolderProperty;
+    private AudioClip lastPreviewed;
 
     private void OnEnable() {
         languageNameProperty = serializedObject.FindProperty("_LocaleCode");
         assetSourceFolderProperty = serializedObject.FindProperty("assetSourceFolder");
+        lastPreviewed = null;
     }
 
     public override void OnInspectorGUI() {
@@ -167,10 +169,88 @@ public class LocalizationEditor : Editor {
 
                 // Show the object field
                 EditorGUILayout.ObjectField(" ", entry.asset, typeof(UnityEngine.Object), false);
+
+                // for AudioClips, add a little play preview button
+                if ( entry.asset.GetType() == typeof(UnityEngine.AudioClip) ) {
+                    var rect = GUILayoutUtility.GetLastRect();
+                    
+                    EditorGUI.EndDisabledGroup();
+                    bool isPlaying = IsClipPlaying( (AudioClip)entry.asset );
+                    if ( lastPreviewed == (AudioClip)entry.asset && isPlaying ) {
+                        rect.width = 54;
+                        rect.x += EditorGUIUtility.labelWidth - 56;
+                        if ( GUI.Button(rect, "▣ Stop" ) ) {
+                            StopAllClips();
+                            lastPreviewed = null;
+                        }
+                    } else {
+                        rect.width = 18;
+                        rect.x += EditorGUIUtility.labelWidth - 20;
+                        if ( GUI.Button(rect, "▸") ) {
+                            PlayClip( (AudioClip)entry.asset );
+                            lastPreviewed = (AudioClip)entry.asset;
+                        }
+                    }
+                    EditorGUI.BeginDisabledGroup(true);
+                }
+
                 EditorGUI.EndDisabledGroup();
                 EditorGUILayout.Space();
             }
 
         }
+    }
+
+    // below is some terrible reflection needed for the AudioClip preview
+    // terrible hack from https://forum.unity.com/threads/way-to-play-audio-in-editor-using-an-editor-script.132042/#post-4767824
+    public static void PlayClip(AudioClip clip, int startSample = 0, bool loop = false)
+    {
+        System.Reflection.Assembly unityEditorAssembly = typeof(AudioImporter).Assembly;
+        System.Type audioUtilClass = unityEditorAssembly.GetType("UnityEditor.AudioUtil");
+        System.Reflection.MethodInfo method = audioUtilClass.GetMethod(
+            "PlayClip",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public,
+            null,
+            new System.Type[] { typeof(AudioClip), typeof(int), typeof(bool) },
+            null
+        );
+        method.Invoke(
+            null,
+            new object[] { clip, startSample, loop }
+        );
+    }
+
+    public static void StopAllClips()
+    {
+        System.Reflection.Assembly unityEditorAssembly = typeof(AudioImporter).Assembly;
+        System.Type audioUtilClass = unityEditorAssembly.GetType("UnityEditor.AudioUtil");
+        System.Reflection.MethodInfo method = audioUtilClass.GetMethod(
+            "StopAllClips",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public,
+            null,
+            new System.Type[] { },
+            null
+        );
+        method.Invoke(
+            null,
+            new object[] { }
+        );
+    }
+
+    public static bool IsClipPlaying(AudioClip clip)
+    {
+        System.Reflection.Assembly unityEditorAssembly = typeof(AudioImporter).Assembly;
+        System.Type audioUtilClass = unityEditorAssembly.GetType("UnityEditor.AudioUtil");
+        System.Reflection.MethodInfo method = audioUtilClass.GetMethod(
+            "IsClipPlaying",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public,
+            null,
+            new System.Type[] { typeof(AudioClip) },
+            null
+        );
+        return (bool)method.Invoke(
+            null,
+            new object[] { clip }
+        );
     }
 }

--- a/Editor/LocalizationEditor.cs
+++ b/Editor/LocalizationEditor.cs
@@ -207,8 +207,19 @@ public class LocalizationEditor : Editor {
     {
         System.Reflection.Assembly unityEditorAssembly = typeof(AudioImporter).Assembly;
         System.Type audioUtilClass = unityEditorAssembly.GetType("UnityEditor.AudioUtil");
+
+        // The name of the method we want to invoke changed in 2020.2, so
+        // we'll do a little version testing here
+        string methodName;
+
+#if UNITY_2020_2_OR_NEWER
+        methodName = "PlayPreviewClip";
+#else
+        methodName = "PlayClip";
+#endif
+
         System.Reflection.MethodInfo method = audioUtilClass.GetMethod(
-            "PlayClip",
+            methodName,
             System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public,
             null,
             new System.Type[] { typeof(AudioClip), typeof(int), typeof(bool) },
@@ -224,8 +235,19 @@ public class LocalizationEditor : Editor {
     {
         System.Reflection.Assembly unityEditorAssembly = typeof(AudioImporter).Assembly;
         System.Type audioUtilClass = unityEditorAssembly.GetType("UnityEditor.AudioUtil");
+
+        // The name of the method we want to invoke changed in 2020.2, so
+        // we'll do a little version testing here
+        string methodName;
+
+#if UNITY_2020_2_OR_NEWER
+        methodName = "StopAllPreviewClips";
+#else
+        methodName = "StopAllClips";
+#endif
+
         System.Reflection.MethodInfo method = audioUtilClass.GetMethod(
-            "StopAllClips",
+            methodName,
             System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public,
             null,
             new System.Type[] { },
@@ -241,6 +263,19 @@ public class LocalizationEditor : Editor {
     {
         System.Reflection.Assembly unityEditorAssembly = typeof(AudioImporter).Assembly;
         System.Type audioUtilClass = unityEditorAssembly.GetType("UnityEditor.AudioUtil");
+
+        // The name of the method we want to invoke AND its parameters
+        // changed in 2020.2, so we'll do a little version testing here
+#if UNITY_2020_2_OR_NEWER
+        System.Reflection.MethodInfo method = audioUtilClass.GetMethod(
+            "IsPreviewClipPlaying",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public
+        );
+        return (bool)method.Invoke(
+            null,
+            null
+        );
+#else
         System.Reflection.MethodInfo method = audioUtilClass.GetMethod(
             "IsClipPlaying",
             System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public,
@@ -252,5 +287,6 @@ public class LocalizationEditor : Editor {
             null,
             new object[] { clip }
         );
+#endif
     }
 }


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

there's currently no easy way to verify that your assigned audio clip matches the localized text

* **What is the new behavior (if this is a feature change)?**

added little "▸" button in Localization inspector to preview voice over audioclips

![image](https://user-images.githubusercontent.com/2285943/104793180-60166980-576f-11eb-9a5e-943174a2562c.png)

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

nope, only a modification to an editor-only inspector

* **Other information**:

there's a bit of nasty reflection used to preview the audioclips since UnityEditor.AudioUtil isn't exposed, but I think it's perfectly reasonable for editor-only tools code
