### PR TITLE
change private DialogueUI members to protected

### DIFF
--- a/Runtime/Views/DialogueUI.cs
+++ b/Runtime/Views/DialogueUI.cs
@@ -102,15 +102,15 @@ namespace Yarn.Unity {
         /// When true, the Runner has signaled to finish the current line
         /// asap.
         /// </summary>
-        private bool finishCurrentLine = false;
+        protected bool finishCurrentLine = false;
 
         // The method that we should call when the user has chosen an
         // option. Externally provided by the DialogueRunner.
-        private System.Action<int> currentOptionSelectionHandler;
+        protected System.Action<int> currentOptionSelectionHandler;
 
         // When true, the DialogueRunner is waiting for the user to press
         // one of the option buttons.
-        private bool waitingForOptionSelection = false;
+        protected bool waitingForOptionSelection = false;
 
         /// <summary>
         /// A <see cref="UnityEngine.Events.UnityEvent"/> that is called
@@ -381,7 +381,7 @@ namespace Yarn.Unity {
 
         /// Show a list of options, and wait for the player to make a
         /// selection.
-        private  IEnumerator DoRunOptions (DialogueOption[] dialogueOptions, System.Action<int> selectOption)
+        protected IEnumerator DoRunOptions (DialogueOption[] dialogueOptions, System.Action<int> selectOption)
         {
             // Do a little bit of safety checking
             if (dialogueOptions.Length > optionButtons.Count) {


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [ ] Feature
- [x] Something else

* **What is the current behavior?** (You can also link to an open issue here)

Several DialogueUI members are private, which makes it more difficult to make new classes that inherit from DialogueUI and customize behavior

* **What is the new behavior (if this is a feature change)?**

changed private members to protected instead... DoRunLine() is already set to protected, DoRunOptions() should be too? we might as well set everything to protected while we're at it? just a little QoL change to make YS more moddable

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no breaks anticipated, just increasing the access level a little more

* **Other information**:

