### PR TITLE
add UnityEngine.InputSystem to YarnSpinner.Unity.Example.asmdef

### DIFF
--- a/Samples~/YarnSpinner.Unity.Example.asmdef
+++ b/Samples~/YarnSpinner.Unity.Example.asmdef
@@ -2,14 +2,16 @@
     "name": "YarnSpinner.Unity.Example",
     "references": [
         "YarnSpinner.Unity",
-        "Unity.TextMeshPro"
+        "Unity.TextMeshPro",
+        "Unity.InputSystem"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
tl;dr when I updated some Samples to be compatible with InputSystem, I forgot to add UnityEngine.InputSystem to the YarnSpinner.Unity.Example.asmdef

* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

this ends up breaking automated CI compiles under specific (and rare) circumstances:
1. import YarnSpinner as a local package via Git submodule
2. CI imports all Samples even if it's inside \Samples~\
3. compile fails because Samples can't find UnityEngine.InputSystem


* **What is the new behavior (if this is a feature change)?**

add UnityEngine.InputSystem to the YarnSpinner.Unity.Example.asmdef


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

the original issue didn't affect most users I think, since either (1) Unity ignores the \Samples~\ folder (which is why I didn't catch the bug before?) or (2) users import Samples subfolders individually, so wouldn't Unity ignore the YarnSpinner.Unity.Example.asmdef in the root of the Samples folder anyway?

if the user doesn't have InputSystem package imported, the .asmdef reference will be null and it'll be ignored


* **Other information**:

sorry