### PR TITLE
add "Assign to Existing Yarn Program" button to Yarn script inspector

### DIFF
--- a/Editor/YarnImporterEditor.cs
+++ b/Editor/YarnImporterEditor.cs
@@ -72,13 +72,22 @@ public class YarnImporterEditor : ScriptedImporterEditor
         EditorGUILayout.PropertyField(baseLanguageIdProperty);
 
         if (destinationYarnProgram == null) {
-            EditorGUILayout.HelpBox("This script is not currently part of a Yarn Program. Either add one in the field above, or click Create New Yarn Program.", MessageType.Info);
-            if (GUILayout.Button("Create New Yarn Program")) {
+            EditorGUILayout.HelpBox("This script is not currently part of a Yarn Program, so it can't be compiled or loaded into a Dialogue Runner. Either click Create New Yarn Program, or Assign to Existing Yarn Program.", MessageType.Info);
+            if (GUILayout.Button("Create New Yarn Program...")) {
                 YarnImporterUtility.CreateYarnProgram(target as YarnImporter);
                 
                 UpdateDestinationProgram();
 
             }
+            if (GUILayout.Button("Assign to Existing Yarn Program...")) {
+                var programPath = EditorUtility.OpenFilePanelWithFilters("Select an existing Yarn Program", Application.dataPath, new string[] {"Yarn Program (.yarnprogram)", "yarnprogram"} );
+                programPath = "Assets" + programPath.Substring( Application.dataPath.Length );
+                if ( !string.IsNullOrEmpty(programPath) ) {
+                    YarnImporterUtility.AssignScriptToProgram( (target as YarnImporter).assetPath, programPath);
+                }
+                UpdateDestinationProgram();
+            }
+            
         } else {
             using (new EditorGUI.DisabledGroupScope(true)) {
                 EditorGUILayout.ObjectField("Program", destinationYarnProgram, typeof(YarnProgramImporter), false);

--- a/Editor/YarnImporterUtility.cs
+++ b/Editor/YarnImporterUtility.cs
@@ -136,19 +136,31 @@ internal static class YarnImporterUtility
         AssetDatabase.ImportAsset(destinationPath);
         AssetDatabase.SaveAssets();
 
-        var programImporter = AssetImporter.GetAtPath(destinationPath) as YarnProgramImporter;
-        programImporter.sourceScripts.Add(AssetDatabase.LoadAssetAtPath<TextAsset>(path));
+        AssignScriptToProgram(path, destinationPath);
 
+        return destinationPath;
+
+    }
+
+    /// <summary>
+    /// Assign a .yarn TextAsset file found at sourcePath to the YarnProgramImporter found at programPath
+    /// </summary>
+    internal static void AssignScriptToProgram(string sourcePath, string programPath) {
+        AssignScriptToProgram(AssetDatabase.LoadAssetAtPath<TextAsset>(sourcePath), AssetImporter.GetAtPath(programPath) as YarnProgramImporter);
+    }
+
+    /// <summary>
+    /// Assign a .yarn TextAsset file newSourceScript to the YarnProgramImporter programImporter
+    /// </summary>
+    internal static void AssignScriptToProgram(TextAsset newSourceScript, YarnProgramImporter programImporter) {
+        programImporter.sourceScripts.Add(newSourceScript);
         EditorUtility.SetDirty(programImporter);
 
         // Reimport the program to make it generate its default string
         // table, if needed
         programImporter.SaveAndReimport();
-
-        return destinationPath;
-        
-
     }
+
 
     /// <summary>
     /// Creates a new localization CSV file for the specified object, for


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

Currently, there's only a "Create New Yarn Program" button, and there is no easy way to assign a Yarn script to an existing Yarn program. The help box text is outdated and suggests that we used to let the user assign the Yarn Program directly. I imagine there's good reasons we don't, but we still need similar functionality.

* **What is the new behavior (if this is a feature change)?**

![image](https://user-images.githubusercontent.com/2285943/108010815-c6431600-6fd3-11eb-8e5e-7a76f63a1dca.png)

Added an extra button, updated help text (to explain a bit more what a Yarn Program is), and there's some extra functions for this in YarnImporterUtility

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Shouldn't break anything, just editor-side QoL UX stuff

* **Other information**:

