### PR TITLE
quick fix for issue #58 (in Space sample, move AddFunction to Awake() instead of Start() )

### DIFF
--- a/Samples~/Space/Scripts/NodeVisitedTracker.cs
+++ b/Samples~/Space/Scripts/NodeVisitedTracker.cs
@@ -17,9 +17,14 @@ namespace Yarn.Unity.Example
         [SerializeField] Yarn.Unity.DialogueRunner dialogueRunner;
 #pragma warning restore 0649
 
+        // a HashSet is like a List or Array except it can't guarantee the order of items 
+        // which is OK if you don't care about order and just want to search inside it, like we do here!
+        // but you could replace this List<string> if you wanted to log the precise order of visited nodes, etc.
         private HashSet<string> _visitedNodes = new HashSet<string>();
 
-        void Start()
+        // we call AddFunction in Awake instead of Start, to ensure the Yarn function "visited()" 
+        // is added to the Dialogue Runner before it starts automatically (if configured to start automatically)
+        void Awake()
         {
             // Register a function on startup called "visited" that lets
             // Yarn scripts query to see if a node has been run before.


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

If the user enables "Start Automatically" on the Space sample (even though they're not supposed to lol), or if the user tries to use the NodeVisitedTracker function example outside of the Space sample, then the Yarn script could potentially call `visited()` before the function actually gets registered on the Dialogue Runner

as documented in issue #58 

* **What is the new behavior (if this is a feature change)?**

add `visited()` to DialogueRunner in Awake() instead of Start(), thereby guaranteeing the function will already be there before Dialogue Runner gets to `Start()`

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

if users have modified their NodeVisitedTracker.cs then maybe there'll be a merge conflict or something

* **Other information**:

I also added some brief explaining about what the HashSet was, since this is meant to be a teaching sample project, and I imagine many intermediate Unity users might not be familiar with HashSets
