### PR TITLE
fix error message "ReflectionTypeLoadException: Exception of type 'Sy…

### DIFF
--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Yarn.Unity
 {
@@ -195,7 +196,7 @@ namespace Yarn.Unity
 
             // In each assembly, find all types that descend from MonoBehaviour
             foreach (var assembly in allAssemblies) {
-                foreach (var type in assembly.GetTypes()) {
+                foreach (var type in assembly.GetLoadableTypes().Where(t => t.IsSubclassOf(typeof(MonoBehaviour)))) {
 
                     // We only care about MonoBehaviours
                     if (typeof(MonoBehaviour).IsAssignableFrom(type) == false) {
@@ -1528,4 +1529,22 @@ namespace Yarn.Unity
     }
 
     #endregion
+
+    public static class AssemblyExtensions
+    {
+        /// <summary>
+        /// Assembly.GetTypes() can throw in some cases.  This extension will catch that exception and return only the types which were successfully loaded from the assembly.
+        /// </summary>
+        public static IEnumerable<System.Type> GetLoadableTypes(this Assembly @this)
+        {
+            try
+            {
+                return @this.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                return e.Types.Where(t => t != null);
+            }
+        }
+    }
 }


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

If you add certain assemblies (e.g. from other packages) that are configured in some way (idk the details), then Reflection can't seem to access these assemblies properly.

This is a problem when Dialogue Runner does a reflection-walk to look for MonoBehaviours with YarnCommand attributes... because it'll come across an assembly where it can't load the types. This throws the exception error: "ReflectionTypeLoadException: Exception of type 'System.Reflection.ReflectionTypeLoadException' was thrown. System.Reflection.Assembly.GetTypes()"

* **What is the new behavior (if this is a feature change)?**

Instead of using GetTypes(), we now use an extension method called GetLoadableTypes() that checks to see if the types are null. I basically took code from https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MRTK/Core/Extensions/AssemblyExtensions.cs since they encountered a similar issue -- see https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8331

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It shouldn't affect anyone adversely, functionality is still basically the same.

* **Other information**:

