### PR TITLE
 Adds SetDialogueViews function so MarkLineComplete responds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- You can now add dialogue views to dialogue runner at any time.
 - The dialogue runner can now be configured to log less to the console, reducing the amount of noise it generates there. (@radiatoryang)
 - Warning messages and errors now appear to help users diagnose two common problems: (1) not adding a Command properly, (2) can't find a localization entry for a line (either because of broken line tag or bad connection to Localization Database) (@radiatoryang)
 - Added a helpbox on the LocalizationDatabase inspector to tell user how to add scripts to a localization: inspect the Yarn script, not the localization database

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -531,6 +531,26 @@ namespace Yarn.Unity
         /// <seealso cref="AddFunction{TResult}(string, Func{TResult})"/>
         public void RemoveFunction(string name) => Dialogue.Library.DeregisterFunction(name);
 
+        /// <summary>
+        /// Sets the dialogue views and makes sure the callback <see cref="DialogueViewBase.MarkLineComplete"/>
+        /// will respond correctly.
+        /// </summary>
+        /// <param name="views">The array of views to be assigned.</param>
+        public void SetDialogueViews(DialogueViewBase[] views)
+        {
+            dialogueViews = views;
+
+            Action continueAction = OnViewUserIntentNextLine;
+            foreach (var dialogueView in dialogueViews) {
+                if (dialogueView == null) {
+                    Debug.LogWarning("The 'Dialogue Views' field contains a NULL element.", gameObject);
+                    continue;
+                }
+
+                dialogueView.onUserWantsLineContinuation = continueAction;
+            }
+        }
+
         #region Private Properties/Variables/Procedures
 
         /// <summary>


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

Right now if you add a view to dialogueViews in DialogueRunner after Start the onUserWantsLineContinuation callback is never assigned. Because of this DialogueViewBase.MarkLineComplete will never be called.

* **What is the new behavior (if this is a feature change)?**

This adds a function to DialogueRunner to allow you to set dialogue views and have onUserWantsLineContinuation be assigned. Because onUserWantsLineContinuation is marked internal the assignment has to happen with in the same assembly.

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

This does not introduce breaking changes.

* **Other information**:

It might be worth changing `public DialogueViewBase[] dialogueViews;` to `[SerializedField] DialogueViewBase[] dialogueViews = default;` as any assignment will result in a scenario where you can never make DialogueViewBase.MarkLineComplete be triggered. Maybe there is still value in allowing it be assigned to null.