### PR TITLE
Use version range expression in *.asmdef

### DIFF
--- a/Editor/YarnSpinner.Unity.Editor.asmdef
+++ b/Editor/YarnSpinner.Unity.Editor.asmdef
@@ -20,12 +20,12 @@
     "versionDefines": [
         {
             "name": "com.unity.addressables",
-            "expression": "1",
+            "expression": "[1.0,2.0)",
             "define": "USE_ADDRESSABLES"
         },
         {
             "name": "com.unity.inputsystem",
-            "expression": "1",
+            "expression": "[1.0,2.0)",
             "define": "USE_INPUTSYSTEM"
         }
     ],

--- a/Runtime/YarnSpinner.Unity.asmdef
+++ b/Runtime/YarnSpinner.Unity.asmdef
@@ -17,12 +17,12 @@
     "versionDefines": [
         {
             "name": "com.unity.addressables",
-            "expression": "1",
+            "expression": "[1.0,2.0)",
             "define": "USE_ADDRESSABLES"
         },
         {
             "name": "com.unity.inputsystem",
-            "expression": "1",
+            "expression": "[1.0,2.0)",
             "define": "USE_INPUTSYSTEM"
         }
     ],

--- a/Tests/Editor/YarnSpinnerEditorTests.asmdef
+++ b/Tests/Editor/YarnSpinnerEditorTests.asmdef
@@ -23,7 +23,7 @@
     "versionDefines": [
         {
             "name": "com.unity.addressables",
-            "expression": "1",
+            "expression": "[1.0,2.0)",
             "define": "USE_ADDRESSABLES"
         }
     ],

--- a/Tests/Runtime/YarnSpinnerTests.asmdef
+++ b/Tests/Runtime/YarnSpinnerTests.asmdef
@@ -22,7 +22,7 @@
     "versionDefines": [
         {
             "name": "com.unity.addressables",
-            "expression": "1",
+            "expression": "[1.0,2.0)",
             "define": "USE_ADDRESSABLES"
         }
     ],


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

Importing beta 3 and beta 4 for me causes tons of these types of errors in the log: 

![image](https://user-images.githubusercontent.com/9920963/113369488-73c57b00-932f-11eb-8298-7f7724ce9531.png)

It seems like it's because "You must use at least the major and minor components of a version in an expression." according to the Unity docs, but only `1` was specified. 

* **What is the new behavior (if this is a feature change)?**

I updated the version ranges to match what was specified here: 
https://docs.unity3d.com/Manual/ScriptCompilationAssemblyDefinitionFiles.html#version-define-expressions


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

I don't think so, just fixes an error in the log. 


* **Other information**:

Let me know any changes you require. Thanks
