### PR TITLE
Command parameters can now contain spaces with double quotes

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+patreon: secretlab

--- a/.github/ISSUE_TEMPLATE/bug_report_beta.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_beta.md
@@ -31,6 +31,8 @@ letting us know about bugs and other problems while we get things ready for rele
   - Yarn Spinner Version: 
   - Unity Version:
 
+<!-- Please specify which beta version of Yarn Spinner this issue is for. For example, 'v2.0.0-beta1'. -->
+
 **Other information** 
 
 <!-- For example, a detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context... -->

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 [Yarn Spinner](https://yarnspinner.dev) is the friendly tool for writing dialogue games. This repo contains the Unity integration; you can find the core [Yarn Spinner compiler](https://github.com/YarnSpinnerTool/YarnSpinner) in its own repository.
 
+## Join Our Discord!
+
+For help, support, discussion, and chill community times, come and join the [Yarn Spinner Discord](https://discord.gg/9CvsQfS)!
+
 ## Getting Started
 
 To get started, you'll need to install Yarn Spinner in your Unity project. Yarn Spinner is available as a package via [OpenUPM](https://openupm.com), and via direct download as a `.unitypackage` file.


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [X ] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)
- [X] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [X] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/YarnSpinnerTool/YarnSpinner-Unity/issues/104
When using a command like `<<add-recipe "My Recipe Name">>` the command is given three parameters ("My, Recipe, and Name"), instead of a single one ("My Recipe Name").

* **What is the new behavior (if this is a feature change)?**
Using `<<add-recipe "My Recipe Name">>` now properly adds just one parameter to the command "My Recipe Name".


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes if they were using quotes as part of a game object name, or as part of something to be expected as a parameter. Highly doubt it though.


* **Other information**:
Overalll a good addition in my opinion
