### PR TITLE
Command parameters can now contain spaces with double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 * `InMemoryVariableStorage` now throws an exception if you attempt to get or set a variable whose name doesn't start with `$`.
+* Command parameters can now be grouped with double quotes. eg. `<<add-recipe "Banana Sensations">` and `<<move "My Game Object" LocationName>>` (@andiCR)
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@ The following people have contributed to the development of Yarn Spinner. If you
 * 2018: Damon 'demanrisu' Reece <de@coy.ninja>
 * 2019: Tamme Schichler <tamme@schichler.dev>
 * 2020: @Schroedingers-Cat, Robert Yang (https://debacle.us)
+* 2021: @andiCR, Andrés Cartín (andres@treeinteractivecr.com)

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -33,6 +33,7 @@ using System.Reflection;
 using System;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Yarn.Unity
 {
@@ -184,6 +185,11 @@ namespace Yarn.Unity
         /// Populated in the <see cref="InitializeClass"/> method.
         /// </summary>
         private static Dictionary<string, MethodInfo> _yarnCommands = new Dictionary<string, MethodInfo>();
+
+        /// <summary>
+        /// Regular expression used to split up command tokens divided with quotes.
+        /// </summary>
+        private static readonly string CMD_REGEX = @"(?<=[ ][\""]|^[\""])[^\""]+(?=[\""][ ]|[\""]$)|(?<=[ ]|^)[^\"" ]+(?=[ ]|$)"; // @"[\""].+?[\""]|[^ ]+" -> This is a simpler form, but won't remove quotes.
 
         /// <summary>
         /// Finds all MonoBehaviour types in the loaded assemblies, and
@@ -929,7 +935,11 @@ namespace Yarn.Unity
 
         private static string[] ParseCommandParameters(string command)
         {
-            return command.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+            // return command.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+            return Regex.Matches(command, cmdRegex)
+                    .Cast<Match>()
+                    .Select(m => m.Value)
+                    .ToArray();
         }
 
 

--- a/Tests/Runtime/DialogueRunnerTests.cs
+++ b/Tests/Runtime/DialogueRunnerTests.cs
@@ -87,6 +87,7 @@ namespace Yarn.Unity.Tests
 
         [TestCase("testCommandInteger DialogueRunner 1 2", "3")]
         [TestCase("testCommandString DialogueRunner a b", "ab")]
+        [TestCase("testCommandString DialogueRunner \"a b\" \"c d\"", "a bc d")]
         [TestCase("testCommandGameObject DialogueRunner Sphere", "Sphere")]
         [TestCase("testCommandComponent DialogueRunner Sphere", "Sphere's MeshRenderer")]
         [TestCase("testCommandGameObject DialogueRunner DoesNotExist", "(null)")]


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [X ] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)
- [X] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [X] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/YarnSpinnerTool/YarnSpinner-Unity/issues/104
When using a command like `<<add-recipe "My Recipe Name">>` the command is given three parameters ("My, Recipe, and Name"), instead of a single one ("My Recipe Name").

* **What is the new behavior (if this is a feature change)?**
Using `<<add-recipe "My Recipe Name">>` now properly adds just one parameter to the command "My Recipe Name".


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes if they were using quotes as part of a game object name, or as part of something to be expected as a parameter. Highly doubt it though.


* **Other information**:
Overalll a good addition in my opinion
