### PR TITLE
.started instead of .performed

### DIFF
--- a/Runtime/Views/LineView.cs
+++ b/Runtime/Views/LineView.cs
@@ -208,12 +208,12 @@ namespace Yarn.Unity
             // configure it
             if (continueActionType == ContinueActionType.InputSystemActionFromAsset && continueActionReference != null)
             {
-                continueActionReference.action.performed += UserPerformedSkipAction;
+                continueActionReference.action.started += UserPerformedSkipAction;
             }
 
             // The custom skip action always starts disabled
             continueAction?.Disable();
-            continueAction.performed += UserPerformedSkipAction;
+            continueAction.started += UserPerformedSkipAction;
 #endif
         }
 


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [*] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

Press events .performed. 

* **What is the new behavior (if this is a feature change)?**

For Press events .started and .performed are called at the same time. However .performed can be called multiple times under certain circumstances. So .started should be used.

https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/manual/Interactions.html#press

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

