### PR TITLE
Inspector Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Yarn script compile errors will prevent play mode.
 
+- The `YarnNode` attribute can be added onto string values to restrict the values to node names. For example:
+
+  ```cs
+  YarnProject SomeProject;
+
+  [YarnNode(nameof(SomeProject))]
+  string TargetNode; // will take whatever nodes exist in the linked project
+
+  DialogueRunner SomeRunner;
+
+  [YarnNode(nameof(SomeRunner))]
+  string TargetNode2; // will refer to whatever the runner has loaded currently
+  ```
+
 ### Changed
 
 - Updated to support new error handling in Yarn Spinner. 

--- a/Editor/Importers/YarnProjectImporter.cs
+++ b/Editor/Importers/YarnProjectImporter.cs
@@ -443,7 +443,7 @@ namespace Yarn.Unity.Editor
                 compiledBytes = memoryStream.ToArray();
             }
 
-            project.compiledYarnProgram = compiledBytes;
+            project.Compile(compiledBytes);
 
 #if YARNSPINNER_DEBUG
             UnityEngine.Profiling.Profiler.enabled = false;

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -288,7 +288,7 @@ namespace Yarn.Unity
         /// </summary>        
         public void SetProject(YarnProject newProject)
         {
-            Dialogue.SetProgram(newProject.GetProgram());
+            Dialogue.SetProgram(newProject.YarnProgram);
             lineProvider.YarnProject = newProject;
         }
 
@@ -706,7 +706,7 @@ namespace Yarn.Unity
                     Debug.LogError($"DialogueRunner wanted to load a Yarn Project in its Start method, but the Dialogue was already running one. The Dialogue Runner may not behave as you expect.");
                 }
 
-                Dialogue.SetProgram(yarnProject.GetProgram());
+                Dialogue.SetProgram(yarnProject.YarnProgram);
 
                 lineProvider.YarnProject = yarnProject;
 

--- a/Runtime/YarnProject.cs
+++ b/Runtime/YarnProject.cs
@@ -28,6 +28,11 @@ namespace Yarn.Unity
 
         private Program cachedProgram;
 
+        /// <summary>
+        /// The current program associated with this project. If you call
+        /// <see cref="Compile(byte[])"/>, this will automatically update the
+        /// program with a new object.
+        /// </summary>
         public Program YarnProgram
         {
             get
@@ -93,7 +98,7 @@ namespace Yarn.Unity
         /// <summary>
         /// Compiles the program from raw byte data.
         /// </summary>
-        /// <param name="rawData">The raw data derived from compilation.</param>
+        /// <param name="rawData">The raw serialized data derived from compilation.</param>
         public void Compile(byte[] bytecode)
         {
             // we're assuming that if you're using this API, you'll no longer be using the compiled yarn program.

--- a/Runtime/YarnProject.cs
+++ b/Runtime/YarnProject.cs
@@ -1,16 +1,16 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System.Reflection;
+using System;
+using UnityEngine.Serialization;
 
 namespace Yarn.Unity
 {
-
     [HelpURL("https://yarnspinner.dev/docs/unity/components/yarn-programs/")]
     public class YarnProject : ScriptableObject
     {
-
-        [SerializeField]
-        [HideInInspector]
+        [NonSerialized]
+        [Obsolete("Use " + nameof(YarnProgram) + " instead, and " + nameof(Compile) + " to initialize.")]
         public byte[] compiledYarnProgram;
 
         [SerializeField]
@@ -21,9 +21,30 @@ namespace Yarn.Unity
         [HideInInspector]
         public List<Localization> localizations = new List<Localization>();
 
+        [SerializeField]
+        [HideInInspector]
+        [FormerlySerializedAs("compiledYarnProgram")]
+        private byte[] rawData;
+
+        private Program cachedProgram;
+
+        public Program YarnProgram
+        {
+            get
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                SyncCompiledYarnProgram();
+#pragma warning restore CS0618 // Type or member is obsolete
+                if (cachedProgram == null)
+                {
+                    cachedProgram = Program.Parser.ParseFrom(rawData);
+                }
+                return cachedProgram;
+            }
+        }
+
         public Localization GetLocalization(string localeCode)
         {
-
             // If localeCode is null, we use the base localization.
             if (localeCode == null)
             {
@@ -43,13 +64,47 @@ namespace Yarn.Unity
             return baseLocalization;
         }
 
+        [Obsolete("Don't use and remove once 2.0 is released.")]
+        private void SyncCompiledYarnProgram()
+        {
+            if (compiledYarnProgram != null)
+            {
+                ResetProgram(compiledYarnProgram);
+            }
+        }
+
+        private void ResetProgram(byte[] bytecode)
+        {
+            rawData = bytecode;
+            cachedProgram = null;
+        }
+
         /// <summary>
         /// Deserializes a compiled Yarn program from the stored bytes in
         /// this object.
         /// </summary>
+        [Obsolete("Use " + nameof(YarnProgram) + " instead, and " + nameof(Compile) + " to initialize.")]
         public Program GetProgram()
         {
-            return Program.Parser.ParseFrom(compiledYarnProgram);
+            SyncCompiledYarnProgram();
+            return YarnProgram;
+        }
+
+        /// <summary>
+        /// Compiles the program from raw byte data.
+        /// </summary>
+        /// <param name="rawData">The raw data derived from compilation.</param>
+        public void Compile(byte[] bytecode)
+        {
+            // we're assuming that if you're using this API, you'll no longer be using the compiled yarn program.
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (compiledYarnProgram == null)
+            {
+                Debug.LogWarning($"Don't use the obsolete {nameof(compiledYarnProgram)} at the same time as the new API.");
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            ResetProgram(bytecode);
         }
 
         public static void AddYarnFunctionMethodsToLibrary(Library library, params System.Reflection.Assembly[] assemblies) {

--- a/Runtime/YarnPropertyDrawers.cs
+++ b/Runtime/YarnPropertyDrawers.cs
@@ -31,7 +31,8 @@ namespace Yarn.Unity
             var projectFieldName = (attribute as YarnNodeAttribute)?.Project;
             if (projectFieldName == null) { return null; }
 
-            return property.serializedObject.FindProperty(projectFieldName).objectReferenceValue as YarnProject;
+            var target = property.serializedObject.FindProperty(projectFieldName).objectReferenceValue;
+            return target as YarnProject ?? (target as DialogueRunner)?.yarnProject;
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)

--- a/Runtime/YarnPropertyDrawers.cs
+++ b/Runtime/YarnPropertyDrawers.cs
@@ -23,7 +23,7 @@ namespace Yarn.Unity
     {
         private string[] GetNodes(YarnProject project)
         {
-            return project.GetProgram().Nodes.Keys.ToArray();
+            return project.YarnProgram.Nodes.Keys.ToArray();
         }
 
         private YarnProject GetYarnProject(SerializedProperty property)

--- a/Runtime/YarnPropertyDrawers.cs
+++ b/Runtime/YarnPropertyDrawers.cs
@@ -45,13 +45,13 @@ namespace Yarn.Unity
             }
 
             var nodes = GetNodes(project);
-            int index = Math.Max(0, Array.IndexOf(nodes, property.stringValue));
+            int index = Array.IndexOf(nodes, property.stringValue);
             int selected = EditorGUI.Popup(
                 position,
                 new GUIContent(property.displayName, property.tooltip),
-                index,
-                nodes.Select(node => new GUIContent(node)).ToArray());
-            property.stringValue = nodes[selected];
+                index == -1 ? nodes.Length : index,
+                nodes.Select(node => new GUIContent(node)).Append(new GUIContent("None")).ToArray());
+            property.stringValue = selected == nodes.Length ? "" : nodes[selected];
         }
     }
 #endif

--- a/Runtime/YarnPropertyDrawers.cs
+++ b/Runtime/YarnPropertyDrawers.cs
@@ -9,6 +9,14 @@ using UnityEditor;
 
 namespace Yarn.Unity
 {
+    /// <summary>
+    /// Restrict a <see cref="string"/> field into only the nodes available to
+    /// a <see cref="YarnProject"/>.
+    /// </summary>
+    /// <remarks>
+    /// You can also use a <see cref="DialogueRunner"/> to dynamically refer to
+    /// whatever <see cref="YarnProject"/> that it currently is referring to.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Field)]
     public class YarnNodeAttribute : PropertyAttribute
     {

--- a/Runtime/YarnPropertyDrawers.cs
+++ b/Runtime/YarnPropertyDrawers.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using UnityEngine;
+
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using UnityEditor;
+#endif
+
+namespace Yarn.Unity
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class YarnNodeAttribute : PropertyAttribute
+    {
+        public string Project { get; set; }
+
+        public YarnNodeAttribute(string project) => Project = project;
+    }
+
+#if UNITY_EDITOR
+    [CustomPropertyDrawer(typeof(YarnNodeAttribute))]
+    public class YarnNodesDrawer : PropertyDrawer
+    {
+        private string[] GetNodes(YarnProject project)
+        {
+            return project.GetProgram().Nodes.Keys.ToArray();
+        }
+
+        private YarnProject GetYarnProject(SerializedProperty property)
+        {
+            var projectFieldName = (attribute as YarnNodeAttribute)?.Project;
+            if (projectFieldName == null) { return null; }
+
+            return property.serializedObject.FindProperty(projectFieldName).objectReferenceValue as YarnProject;
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            var project = GetYarnProject(property);
+            if (project == null || property.propertyType != SerializedPropertyType.String) 
+            {
+                EditorGUI.PropertyField(position, property, label);
+                return;
+            }
+
+            var nodes = GetNodes(project);
+            int index = Math.Max(0, Array.IndexOf(nodes, property.stringValue));
+            int selected = EditorGUI.Popup(
+                position,
+                new GUIContent(property.displayName, property.tooltip),
+                index,
+                nodes.Select(node => new GUIContent(node)).ToArray());
+            property.stringValue = nodes[selected];
+        }
+    }
+#endif
+}

--- a/Runtime/YarnPropertyDrawers.cs.meta
+++ b/Runtime/YarnPropertyDrawers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 744cb14122cbe9146b185486d168aff9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/DialogueRunnerTest.yarn.meta
+++ b/Tests/Runtime/DialogueRunnerTest.yarn.meta
@@ -1,23 +1,20 @@
 fileFormatVersion: 2
 guid: 40a60c3c28a91d34bbf2088bb0d2824a
 ScriptedImporter:
-  fileIDToRecycleName:
-    4900000: Program
-    4900002: Strings
+  internalIDToNameTable:
+  - first:
+      49: 4900000
+    second: Program
+  - first:
+      49: 4900002
+    second: Strings
   externalObjects: {}
+  serializedVersion: 2
   userData: 
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 11500000, guid: 94073015eacc34c1d8fc6786e43d60ca, type: 3}
-  baseLanguageID: en
-  stringIDs:
-  - line:0e3dc4b
-  - line:0967160
-  - line:04e806e
-  - line:0901fb2
-  AnyImplicitStringIDs: 0
-  isSuccesfullyParsed: 1
-  parseErrorMessage: 
-  baseLanguage: {instanceID: 0}
-  localizations: []
-  localizationDatabase: {instanceID: 0}
+  LastImportHadImplicitStringIDs: 1
+  LastImportHadAnyStrings: 1
+  isSuccessfullyParsed: 1
+  parseErrorMessages: []


### PR DESCRIPTION
Fixes #29.

* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features) -- Need some guidance here. What's the best way to make an Editor UI test?
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->

<!-- To update the documentation on yarnspinner.dev, please submit a pull request to the documentation repository at https://github.com/YarnSpinnerTool/Docs. -->

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?** 

Currently there's no easy way to restrict a property to only node names.

* **What is the new behavior (if this is a feature change)?**

Taken from changelog:

- The `YarnNode` attribute can be added onto string values to restrict the values to node names. For example:

  ```cs
  YarnProject SomeProject;

  [YarnNode(nameof(SomeProject))]
  string TargetNode; // will take whatever nodes exist in the linked project

  DialogueRunner SomeRunner;

  [YarnNode(nameof(SomeRunner))]
  string TargetNode2; // will refer to whatever the runner has loaded currently
  ```

Also I've updated the compiledYarnProgram field to be better encapsulated.

* **Does this pull request introduce a breaking change?**

Yes, I've changed compiledYarnProgram to not be public, so we can do some caching (as we don't want to re-parse the program on each OnGUI event).

I've done my best to keep backwards compatibility, though I've marked some methods as obsolete.

* **Other information**:

It might still re-parse anyways on certain domain reloads, but at least it won't cause performance issues if someone clicks a lot on the property GUI.

I tried to make it auto-detect the program, or to keep some state so people didn't have to add an extra field they weren't going to use elsewhere if they didn't want to, but that wasn't easy and I didn't think it was worth it for all the trouble it would be because most of the time it would be good to manually hook it up anyways (to avoid weird editor magic).