### PR TITLE
Replaced Yarn Project importers delayed input fields with regular ones.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Line Views will now only enable and disable action references if the line view is also configured to use said action.
 
+- Yarn Project importer will now save variable declaration metadata on the first time
+
 ### Removed
 
 ## [v2.0.0-beta5] 2021-08-17

--- a/Editor/Importers/YarnProjectImporter.cs
+++ b/Editor/Importers/YarnProjectImporter.cs
@@ -826,20 +826,16 @@ namespace Yarn.Unity.Editor
             }
             else
             {
-                // Use delayed fields where possible to preserve
-                // responsivity (we don't want to force a serialization on
-                // Unity 2018 after every keystroke, and delayed fields
-                // don't report a change until the user changes focus)
                 switch (property.propertyType)
                 {
                     case SerializedPropertyType.String:
-                        property.stringValue = EditorGUI.DelayedTextField(position, label, property.stringValue);
+                        property.stringValue = EditorGUI.TextField(position, label, property.stringValue);
                         break;
                     case SerializedPropertyType.Float:
-                        property.floatValue = EditorGUI.DelayedFloatField(position, label, property.floatValue);
+                        property.floatValue = EditorGUI.FloatField(position, label, property.floatValue);
                         break;
                     case SerializedPropertyType.Integer:
-                        property.floatValue = EditorGUI.DelayedIntField(position, label, property.intValue);
+                        property.floatValue = EditorGUI.IntField(position, label, property.intValue);
                         break;
                     default:
                         // Just use a regular field for other kinds of
@@ -952,7 +948,7 @@ namespace Yarn.Unity.Editor
                     var wordWrappedTextField = EditorStyles.textField;
                     wordWrappedTextField.wordWrap = true;
 
-                    descriptionProperty.stringValue = EditorGUI.DelayedTextField(descriptionPosition, descriptionProperty.displayName, descriptionProperty.stringValue, wordWrappedTextField);
+                    descriptionProperty.stringValue = EditorGUI.TextField(descriptionPosition, descriptionProperty.displayName, descriptionProperty.stringValue, wordWrappedTextField);
                 }
 
                 if (!propertyIsReadOnly)


### PR DESCRIPTION
The use of delayed importers meant you could run into situations where your input in variables wouldn't be detected and saved.
This was put in as a workaround for Unity 2018 which is no longer supported so we can remove these and use regular input fields.
Fixes #49

* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->

<!-- To update the documentation on yarnspinner.dev, please submit a pull request to the documentation repository at https://github.com/YarnSpinnerTool/Docs. -->

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** 

Details of existing bug are on issue #49 

<!-- If you are fixing a known bug, you can also link to an open issue here. -->

* **What is the new behavior (if this is a feature change)?**

Replaced delayed fields with regular ones, this in effect fixes #49 

<!-- Please describe, in as much detail as you can, what your pull request changes in Yarn Spinner. -->

* **Does this pull request introduce a breaking change?**

Yes, the previous code was designed around some quirks of Unity 2018, but as this is no longer supported it should be fine.
Is still breaking.

<!-- What changes might users need to make in their application due to this PR? -->

* **Other information**:

