### PR TITLE
Fixed exception when viewing a Yarn Project in the inspector that contains no declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `ActionManager` no longer logs every single command that it registers. (#165)
 - Line view should no longer have unusual interactions around enabling and disabling different effects (#161 and #153).
 - Improved the type inference system around the use of functions.
+- Fixed exception when viewing a Yarn Project in the inspector that contains no declarations, in Unity 2021.2 and earlier (#168)
 
 This has two pieces, the first is in YarnSpinner Core and adds in support for partial backwards type inference.
 This means in many situations where either the l-value or r-value of an expression is known that can be used to provide a type to the other side of the equation.

--- a/Editor/Importers/YarnProjectImporter.cs
+++ b/Editor/Importers/YarnProjectImporter.cs
@@ -855,6 +855,15 @@ namespace Yarn.Unity.Editor
 
         private float GetElementHeight(int index, bool useSearch)
         {
+#if !UNITY_2022_1_OR_NEWER
+            // Before Unity 2022.1, this callback gets called with 
+            // index 0 even if the list is empty
+            if (serializedProperty.arraySize == 0)
+            {
+                return 0;
+            }
+#endif
+
             if (useSearch == false || ShouldShowElement(index))
             {
                 var item = serializedProperty.GetArrayElementAtIndex(index);


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] Does it pass all existing unit tests without modification?
    - If not, what did you change?
    - If you altered it significantly, what coverage issue did you fix?
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?**

Fixes YarnSpinnerTool/YarnSpinner-Unity#168
