### PR TITLE
DialogueReference type with property drawer

### DIFF
--- a/Runtime/DialogueReference.cs
+++ b/Runtime/DialogueReference.cs
@@ -1,0 +1,246 @@
+using System;
+using UnityEngine;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Yarn.Unity
+{
+    /// <summary>
+    /// Reference to a dialogue node in a Yarn Project.
+    /// </summary>
+    /// <remarks>
+    /// A combination of Yarn Project asset reference and dialog name,
+    /// allowing to check if the node exists in the project.
+    /// Comes with a property drawer that allows to select the node
+    /// from a drop-down and warns if the node doesn't exist.
+    /// </remarks>
+    [Serializable]
+    public class DialogueReference
+    {
+        /// <summary>
+        /// The Yarn Project asset containing the dialogue node.
+        /// </summary>
+        public YarnProject project;
+        /// <summary>
+        /// The name of the dialogue node in the project.
+        /// </summary>
+        public string nodeName;
+
+        /// <summary>
+        /// Wether the reference has project and node name set.
+        /// Does not check if the node exists in the project.
+        /// </summary>
+        public bool IsSet => project != null && !string.IsNullOrEmpty(nodeName);
+
+        /// <summary>
+        /// Wether project and node name are set and the node exists in the project.
+        /// </summary>
+        /// <remarks>
+        /// This loads the compiled Yarn program, might be expensive to call frequently.
+        /// </remarks>
+        public bool IsSetAndExists => IsSet && project.GetProgram().Nodes.ContainsKey(nodeName);
+
+        /// <summary>
+        /// Create an empty dialogue reference.
+        /// </summary>
+        public DialogueReference() { }
+
+        /// <summary>
+        /// Create a dialogue reference with a given project and node name.
+        /// </summary>
+        /// <param name="project">Yarn Project asset containing the node.</param>
+        /// <param name="nodeName">Name of the node in the project asset.</param>
+        public DialogueReference(YarnProject project, string nodeName)
+        {
+            this.project = project;
+            this.nodeName = nodeName;
+        }
+    }
+
+#if UNITY_EDITOR
+    /// <summary>
+    /// Property drawer for <see cref="DialogueReference"/>
+    /// </summary>
+    [CustomPropertyDrawer(typeof(DialogueReference))]
+    public class DialogueReferenceDrawer : PropertyDrawer
+    {
+        const string NodeTextControlNamePrefix = "DialogueReference.NodeName.";
+
+        YarnProject lastProject;
+        string lastNodeName;
+        bool referenceExists;
+        bool editNodeAsText;
+        bool focusNodeTextField;
+
+        GUIContent nodenameContent;
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            var controlId = GUIUtility.GetControlID(FocusType.Passive);
+            position = EditorGUI.PrefixLabel(position, controlId, label);
+
+            var indent = EditorGUI.indentLevel;
+            EditorGUI.indentLevel = 0;
+
+            // -- Yarn Project asset reference
+            var projectProp = property.FindPropertyRelative(nameof(DialogueReference.project));
+
+            YarnProject project = null;
+            if (!projectProp.hasMultipleDifferentValues)
+            {
+                project = (YarnProject)projectProp.objectReferenceValue;
+            }
+
+            var showNodeDropdown = (projectProp.hasMultipleDifferentValues || project != null);
+            if (showNodeDropdown)
+            {
+                position.width /= 2f;
+            }
+
+            EditorGUI.PropertyField(position, projectProp, GUIContent.none);
+
+            if (showNodeDropdown)
+            {
+                position.x += position.width;
+            }
+
+            // -- Node name drop down
+            var nodeNameProp = property.FindPropertyRelative(nameof(DialogueReference.nodeName));
+            if (editNodeAsText || projectProp.hasMultipleDifferentValues)
+            {
+                var controlName = NodeTextControlNamePrefix + controlId;
+
+                // Multi-selection with different projects,
+                // just show a text field to edit the node name.
+                // Most of the time, it will show the mixed value dash (—).
+                GUI.SetNextControlName(controlName);
+                EditorGUI.PropertyField(position, nodeNameProp, GUIContent.none);
+
+                if (editNodeAsText)
+                {
+                    if (focusNodeTextField)
+                    {
+                        // Focusing the text field is delayed like this because
+                        // the control needs to exist first before we can focus it
+                        focusNodeTextField = false;
+                        EditorGUI.FocusTextInControl(controlName); 
+                    }
+                    else if (ShouldEndEditing(controlName))
+                    {
+                        editNodeAsText = false;
+                        HandleUtility.Repaint();
+                    }
+                }
+            }
+            else if (showNodeDropdown)
+            {
+                var nodeName = nodeNameProp.stringValue;
+                var nodeNameSet = !string.IsNullOrEmpty(nodeName);
+
+                // Cached check if node exists in project
+                if (lastProject != project || lastNodeName != nodeName)
+                {
+                    lastProject = project;
+                    lastNodeName = nodeName;
+                    referenceExists = project.GetProgram().Nodes.ContainsKey(nodeName);
+                }
+
+                if (nodenameContent == null)
+                {
+                    nodenameContent = new GUIContent();
+                }
+
+                // Show warning icon if not does not exist in selected project
+                nodenameContent.text = nodeName;
+                if (referenceExists || !nodeNameSet)
+                {
+                    nodenameContent.image = null;
+                }
+                else if (nodenameContent.image == null)
+                {
+                    nodenameContent.image = EditorGUIUtility.IconContent("d_console.warnicon.sml").image;
+                }
+
+                var hasMixedNodeValues = nodeNameProp.hasMultipleDifferentValues;
+                EditorGUI.showMixedValue = hasMixedNodeValues;
+
+                // Generate menu with node list only when user actually opens it
+                if (EditorGUI.DropdownButton(position, nodenameContent, FocusType.Keyboard))
+                {
+                    var menu = new GenericMenu();
+
+                    menu.AddItem(new GUIContent("Edit..."), false, () => {
+                        editNodeAsText = true;
+                        focusNodeTextField = true;
+                    });
+
+                    GenericMenu.MenuFunction copyAction = null;
+                    if (nodeNameSet && !hasMixedNodeValues)
+                    {
+                        copyAction = () => {
+                            EditorGUIUtility.systemCopyBuffer = nodeName;
+                        };
+                    }
+                    menu.AddItem(new GUIContent("Copy"), false, copyAction);
+
+                    GenericMenu.MenuFunction pasteAction = null;
+                    var pasteNode = EditorGUIUtility.systemCopyBuffer;
+                    if (!string.IsNullOrEmpty(pasteNode))
+                    {
+                        pasteAction = () => {
+                            nodeNameProp.stringValue = pasteNode;
+                            nodeNameProp.serializedObject.ApplyModifiedProperties();
+                        };
+                    }
+                    menu.AddItem(new GUIContent("Paste"), false, pasteAction);
+
+                    menu.AddSeparator("");
+
+                    menu.AddItem(new GUIContent("<None>"), !nodeNameSet, () => {
+                        nodeNameProp.stringValue = "";
+                        nodeNameProp.serializedObject.ApplyModifiedProperties();
+                    });
+
+                    if (!referenceExists && nodeNameSet && !hasMixedNodeValues)
+                    {
+                        menu.AddItem(new GUIContent(nodeName + " (Missing)"), true, () => { 
+                            nodeNameProp.stringValue = nodeName;
+                            nodeNameProp.serializedObject.ApplyModifiedProperties();
+                        });
+                    }
+
+                    foreach (var name in project.GetProgram().Nodes.Keys)
+                    {
+                        menu.AddItem(new GUIContent(name), (name == nodeName && !hasMixedNodeValues), () => { 
+                            nodeNameProp.stringValue = name;
+                            nodeNameProp.serializedObject.ApplyModifiedProperties();
+                        });
+                    }
+
+                    menu.DropDown(position);
+                }
+            }
+
+            EditorGUI.indentLevel = indent;
+
+            EditorGUI.EndProperty();
+        }
+
+        static bool ShouldEndEditing(string controlName)
+        {
+            if (GUI.GetNameOfFocusedControl() != controlName)
+                return false;
+
+            var keyCode = Event.current.keyCode;
+            if (keyCode != KeyCode.Return && keyCode != KeyCode.KeypadEnter)
+                return false;
+
+            return true;
+        }
+    }
+#endif
+}

--- a/Runtime/DialogueReference.cs.meta
+++ b/Runtime/DialogueReference.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d29ac9a78206141ecae7cdfc0bd044c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Since #134 has been closed, I've decided to polish up the property drawer we've been using in our project and create another pull request to resolve #29.

It works a bit differently, adding a `DialogueReference` type encapsulating the project reference and node name. This makes the property drawer a bit tidier, as it doesn't need to look up a separate property, and makes supporting multi-editing much easier. The downside is that you cannot use a single project reference field for multiple node name fields and instead always have a separate project reference for each node name.

It should also have a lot less overhead. Instead of creating a new array each time the drawer is updated, it only checks once if the node exists in the project and then creates the node list for the dropdown only when the user opens it.

What do you think, does this look like something you'd want to merge?

### Todo
- [ ] Add documentation and update changelog
- [ ] Test with Unity versions other than 2021.3
- [ ] Add `DialogueRunner.StartDialogue` overload that takes `DialogueReference` directly

### Overview

Default state when reference is empty:
<img width="378" alt="DIalogueReference-Empty" src="https://user-images.githubusercontent.com/173249/179403727-8fb2bb9b-f925-467b-b36a-f2ece7724935.png">

After project has been selected, node dropdown appears:
<img width="381" alt="DIalogueReference-ProjectOnly" src="https://user-images.githubusercontent.com/173249/179403748-bc7b6b15-296f-4883-8803-26241a67e058.png">

The dropdown contains all nodes in the project as well as edit/copy/paste commands:
<img width="410" alt="DIalogueReference-NodeDropdown" src="https://user-images.githubusercontent.com/173249/179403767-aa63a8ac-d31c-49a9-ae08-f27ef186b8cc.png">

After a node has been selected:
<img width="377" alt="DIalogueReference-ProjectAndNode" src="https://user-images.githubusercontent.com/173249/179403801-61da133c-5cde-413c-ae8c-cdbf6bfa634c.png">

The edit command allows to edit the node name as text:
<img width="378" alt="DIalogueReference-Edit" src="https://user-images.githubusercontent.com/173249/179403809-83681d29-1795-42a4-b702-dc8528b11d3f.png">

If the node doesn't exist in the project, a warning icon is shown:
<img width="377" alt="DIalogueReference-MissingNode" src="https://user-images.githubusercontent.com/173249/179403816-4e3f2113-f375-4ca0-9527-1ea6ace630b4.png">

Multi-editing with matching projects:
<img width="420" alt="DIalogueReference-MultiNode" src="https://user-images.githubusercontent.com/173249/179403827-dca4e8e2-e9f9-4ca9-a7e9-b6112df8cdeb.png">

Multi-editing with mixed projects (in which case node name is always a text field):
<img width="420" alt="DIalogueReference-MultiProject" src="https://user-images.githubusercontent.com/173249/179403835-f3a66f43-94a7-4ba4-b094-0b000d682c99.png">
