### PR TITLE
DialogueRunner.VariableStorage changed to interface instead of MonoBehaviour class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `DialogueRunner.VariableStorage` property is now an interface instead of a class, this allow users to implement their own `VariableStorage` without the restriction of being a MonoBehaviour.
+- `DialogueRunner.VariableStorage` property is now an interface instead of a class, this allow users to implement their own `VariableStorage` without the restriction of being a `MonoBehaviour`.
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+##[2.2.1] 2022-06-14
+
+### Added
+
+- `DialogueRunner.VariableStorage` property is now an interface instead of a class, this allow users to implement their own `VariableStorage` without the restriction of being a MonoBehaviour.
+
 ## [Unreleased]
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,4 @@ The following people have contributed to the development of Yarn Spinner. If you
 * 2021: @andiCR, Andrés Cartín (andres@treeinteractivecr.com)
 * 2021: Shane Duan <github@xsduan.com>
 * 2022: Bernardo Vecchia Stein <jkhulw@sidhion.com>
+* 2022: @Houtamelo, Antônio Pedro Gonçalves Ferreira <antoniopedrogf@hotmail.com>

--- a/Editor/Editors/DialogueRunnerEditor.cs
+++ b/Editor/Editors/DialogueRunnerEditor.cs
@@ -13,6 +13,7 @@ namespace Yarn.Unity.Editor
 
         private SerializedProperty yarnProjectProperty;
         private SerializedProperty variableStorageProperty;
+        private SerializedProperty useMonobehaviourAsVariableStorageProperty;
         private SerializedProperty dialogueViewsProperty;
         private SerializedProperty startNodeProperty;
         private SerializedProperty startAutomaticallyProperty;
@@ -28,6 +29,7 @@ namespace Yarn.Unity.Editor
         {
             yarnProjectProperty = serializedObject.FindProperty(nameof(DialogueRunner.yarnProject));
             variableStorageProperty = serializedObject.FindProperty(nameof(DialogueRunner._variableStorage));
+            useMonobehaviourAsVariableStorageProperty = serializedObject.FindProperty(nameof(DialogueRunner._useMonoBehaviourAsVariableStorage));
             dialogueViewsProperty = serializedObject.FindProperty(nameof(DialogueRunner.dialogueViews));
             startNodeProperty = serializedObject.FindProperty(nameof(DialogueRunner.startNode));
             startAutomaticallyProperty = serializedObject.FindProperty(nameof(DialogueRunner.startAutomatically));
@@ -43,12 +45,21 @@ namespace Yarn.Unity.Editor
         public override void OnInspectorGUI()
         {
             EditorGUILayout.PropertyField(yarnProjectProperty);
-            EditorGUILayout.PropertyField(variableStorageProperty);
-
-            if (variableStorageProperty.objectReferenceValue == null)
+            EditorGUILayout.PropertyField(useMonobehaviourAsVariableStorageProperty);
+            if (useMonobehaviourAsVariableStorageProperty.boolValue)
+            {
+                EditorGUILayout.PropertyField(variableStorageProperty);
+                if (variableStorageProperty.objectReferenceValue == null)
+                {
+                    EditorGUI.indentLevel += 1;
+                    EditorGUILayout.HelpBox($"An {ObjectNames.NicifyVariableName(nameof(InMemoryVariableStorage))} component will be added at run time.", MessageType.Info);
+                    EditorGUI.indentLevel -= 1;
+                }
+            }
+            else
             {
                 EditorGUI.indentLevel += 1;
-                EditorGUILayout.HelpBox($"An {ObjectNames.NicifyVariableName(nameof(InMemoryVariableStorage))} component will be added at run time.", MessageType.Info);
+                EditorGUILayout.HelpBox($"You will need to manually set the variable storage using the {nameof(DialogueRunner.VariableStorage)} property.", MessageType.Info);
                 EditorGUI.indentLevel -= 1;
             }
 

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -77,12 +77,12 @@ namespace Yarn.Unity
         /// The variable storage object.
         /// </summary>
         [UnityEngine.Serialization.FormerlySerializedAs("variableStorage")]
-        [SerializeField] internal VariableStorageBehaviour _variableStorage;
+        [SerializeField] internal IExtendedVariableStorage _variableStorage;
 
         /// <inheritdoc cref="_variableStorage"/>
-        public VariableStorageBehaviour VariableStorage
+        public IExtendedVariableStorage VariableStorage
         {
-            get => _variableStorage; 
+            get => _variableStorage;
             set
             {
                 _variableStorage = value;

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -77,20 +77,20 @@ namespace Yarn.Unity
         /// If true, the DialogueRunner will use the _variableStorage field as the Variable Storage.
         /// If false, you should set your own variable storage by using the VariableStorage property.
         /// </summary>
-        [SerializeField] public bool _useMonoBehaviourAsVariableStorage;
+        [SerializeField] public bool _useMonoBehaviourAsVariableStorage = true;
 
         /// <summary>
         /// The variable storage object.
         /// </summary>
         [UnityEngine.Serialization.FormerlySerializedAs("variableStorage")]
-        [SerializeField] public VariableStorageBehaviour _variableStorage;
+        [SerializeField] internal VariableStorageBehaviour _variableStorage;
 
-        public IExtendedVariableStorage NonSerializedVariableStorage;
+        internal IExtendedVariableStorage _nonMonoBehaviourVariableStorage;
 
         /// <inheritdoc cref="_variableStorage"/>
         public IExtendedVariableStorage VariableStorage
         {
-            get => _useMonoBehaviourAsVariableStorage ? _variableStorage : NonSerializedVariableStorage;
+            get => _useMonoBehaviourAsVariableStorage ? _variableStorage : _nonMonoBehaviourVariableStorage;
             set
             {
                 if (_useMonoBehaviourAsVariableStorage && value is VariableStorageBehaviour behaviour)
@@ -100,14 +100,14 @@ namespace Yarn.Unity
                 else if (_useMonoBehaviourAsVariableStorage)
                 {
                     _variableStorage = null;
-                    NonSerializedVariableStorage = value;
+                    _nonMonoBehaviourVariableStorage = value;
                     _useMonoBehaviourAsVariableStorage = false;
-                    Debug.LogWarning($"Trying to set {nameof(VariableStorage)} with a value that does not inherit {nameof(VariableStorageBehaviour)} when {nameof(_useMonoBehaviourAsVariableStorage)} is true, this is not supported, switching to non-serialized variable instead.");
+                    Debug.LogWarning($"Trying to set {nameof(VariableStorage)} with a value that does not inherit {nameof(VariableStorageBehaviour)} when {nameof(_useMonoBehaviourAsVariableStorage)} is true, this is not supported, switching to non-MonoBehaviour variable instead.");
                 }
                 else
                 {
                     _variableStorage = null;
-                    NonSerializedVariableStorage = value;
+                    _nonMonoBehaviourVariableStorage = value;
                 }
                 
                 if (_dialogue != null)
@@ -1497,7 +1497,7 @@ namespace Yarn.Unity
                 try
                 {
                     var dictionaries = DeserializeAllVariablesFromJSON(saveData);
-                    _variableStorage.SetAllVariables(dictionaries.Item1, dictionaries.Item2, dictionaries.Item3);
+                    VariableStorage.SetAllVariables(dictionaries.Item1, dictionaries.Item2, dictionaries.Item3);
 
                     return true;
                 }
@@ -1593,7 +1593,7 @@ namespace Yarn.Unity
         }
         private string SerializeAllVariablesToJSON()
         {
-            (var floats, var strings, var bools) = _variableStorage.GetAllVariables();
+            (var floats, var strings, var bools) = VariableStorage.GetAllVariables();
 
             SaveData data = new SaveData();
             data.floatKeys = floats.Keys.ToArray();

--- a/Runtime/IExtendedVariableStorage.cs
+++ b/Runtime/IExtendedVariableStorage.cs
@@ -1,5 +1,4 @@
-﻿namespace Yarn.Unity;
-
+﻿namespace Yarn.Unity
 {
     public interface IExtendedVariableStorage : Yarn.IVariableStorage
     {

--- a/Runtime/IExtendedVariableStorage.cs
+++ b/Runtime/IExtendedVariableStorage.cs
@@ -1,0 +1,32 @@
+﻿namespace Yarn.Unity;
+
+{
+    public interface IExtendedVariableStorage : Yarn.IVariableStorage
+    {
+        /// <summary>
+        /// Returns a boolean value representing if a particular variable is
+        /// inside the variable storage.
+        /// </summary>
+        /// <param name="variableName">The name of the variable to check
+        /// for.</param>
+        /// <returns><see langword="true"/> if this variable storage contains a
+        /// value for the variable named <paramref name="variableName"/>; <see
+        /// langword="false"/> otherwise.</returns>
+        bool Contains(string variableName);
+
+        /// <summary>
+        /// Provides a unified interface for loading many variables all at once.
+        /// Will override anything already in the variable storage.
+        /// </summary>
+        /// <param name="clear">Should the load also wipe the storage.
+        /// Defaults to true so all existing variables will be cleared.
+        /// </param>
+        void SetAllVariables(System.Collections.Generic.Dictionary<string,float> floats, System.Collections.Generic.Dictionary<string,string> strings, System.Collections.Generic.Dictionary<string,bool> bools, bool clear = true);
+
+        /// <summary>
+        /// Provides a unified interface for exporting all variables.
+        /// Intended to be a point for custom saving, editors, etc.
+        /// </summary>
+        (System.Collections.Generic.Dictionary<string,float>,System.Collections.Generic.Dictionary<string,string>,System.Collections.Generic.Dictionary<string,bool>) GetAllVariables();
+    }
+}

--- a/Runtime/IExtendedVariableStorage.cs.meta
+++ b/Runtime/IExtendedVariableStorage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90363860d336d334fae2c7cb03e81890
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/VariableStorageBehaviour.cs
+++ b/Runtime/VariableStorageBehaviour.cs
@@ -37,7 +37,7 @@ namespace Yarn.Unity
     /// which means that subclasses of this class can be attached to <see
     /// cref="GameObject"/>s.
     /// </remarks>
-    public abstract class VariableStorageBehaviour : MonoBehaviour, Yarn.IVariableStorage
+    public abstract class VariableStorageBehaviour : MonoBehaviour, IExtendedVariableStorage
     {
         /// <inheritdoc/>
         public abstract bool TryGetValue<T>(string variableName, out T result);
@@ -54,30 +54,13 @@ namespace Yarn.Unity
         /// <inheritdoc/>
         public abstract void Clear();
 
-        /// <summary>
-        /// Returns a boolean value representing if a particular variable is
-        /// inside the variable storage.
-        /// </summary>
-        /// <param name="variableName">The name of the variable to check
-        /// for.</param>
-        /// <returns><see langword="true"/> if this variable storage contains a
-        /// value for the variable named <paramref name="variableName"/>; <see
-        /// langword="false"/> otherwise.</returns>
+        /// <inheritdoc/>
         public abstract bool Contains(string variableName);
 
-        /// <summary>
-        /// Provides a unified interface for loading many variables all at once.
-        /// Will override anything already in the variable storage.
-        /// </summary>
-        /// <param name="clear">Should the load also wipe the storage.
-        /// Defaults to true so all existing variables will be cleared.
-        /// </param>
+        /// <inheritdoc/>
         public abstract void SetAllVariables(System.Collections.Generic.Dictionary<string,float> floats, System.Collections.Generic.Dictionary<string,string> strings, System.Collections.Generic.Dictionary<string,bool> bools, bool clear = true);
 
-        /// <summary>
-        /// Provides a unified interface for exporting all variables.
-        /// Intended to be a point for custom saving, editors, etc.
-        /// </summary>
+        /// <inheritdoc/>
         public abstract (System.Collections.Generic.Dictionary<string,float>,System.Collections.Generic.Dictionary<string,string>,System.Collections.Generic.Dictionary<string,bool>) GetAllVariables();
     }
 }

--- a/Tests/Runtime/DialogueRunnerTests.cs
+++ b/Tests/Runtime/DialogueRunnerTests.cs
@@ -101,7 +101,7 @@ namespace Yarn.Unity.Tests
 
             Assert.IsFalse(success);
         }
-        private void SaveAndLoad_StorageIntegrity(VariableStorageBehaviour storage, Dictionary<string, float> testFloats, Dictionary<string, string> testStrings, Dictionary<string, bool> testBools)
+        private void SaveAndLoad_StorageIntegrity(IExtendedVariableStorage storage, Dictionary<string, float> testFloats, Dictionary<string, string> testStrings, Dictionary<string, bool> testBools)
         {
             var current = storage.GetAllVariables();
 


### PR DESCRIPTION
- [X] Tests for the changes have been added (for bug fixes / features)
  - [X] Does it pass all existing unit tests without modification?
- [X] Docs have been added / updated (for bug fixes / features)
- [X] CHANGELOG.md has been updated to describe this change

* **What kind of change does this pull request introduce?**
- [X] Feature

* **What is the current behavior?**

DialogueRunner.VariableStorage is a MonoBehaviour which doesn't allow users to setup their own implementation of the base class without having a MonoBehaviour as the intermediary.

* **What is the new behavior (if this is a feature change)?**

DialogueRunner.VariableStorage is now an interface called IExtendedVariableStorage.

* **Does this pull request introduce a breaking change?**

No.

- Who will be affected?
  - Is this an internal change, or something meant to be consumed by the end user?
   A: Meant for the end user.
  - If you add API changes, is it easily upgradable from the previous version?
   A: Yes.
- What do you think will be controversial, if any? 
A: The implementation of the DialogueRunner.VariableStorage property.
- How would you describe the cause of the problem and changes to non-technical users if at all possible?
A: Non-technical users won't be affected as the previous functionatily still works in the same manner.
