### PR TITLE
add check for IsEmpty in UnityLocalizedLineProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Added a check for `IsEmpty` in `UnityLocalisedLineProvider.cs` to ensure `stringsTable` and `assetTable` exist and are selected in the editor
+
 ### Removed
 
 ## [2.2.2] 2022-10-31

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,4 @@ The following people have contributed to the development of Yarn Spinner. If you
 * 2021: @andiCR, Andrés Cartín (andres@treeinteractivecr.com)
 * 2021: Shane Duan <github@xsduan.com>
 * 2022: Bernardo Vecchia Stein <jkhulw@sidhion.com>
+* 2022: Jon Lawitts <jon@redstart.io>

--- a/Runtime/LineProviders/UnityLocalisedLineProvider.cs
+++ b/Runtime/LineProviders/UnityLocalisedLineProvider.cs
@@ -48,11 +48,11 @@ namespace Yarn.Unity
         public override void Start()
         {
             // doing an initial load of the strings
-            if (stringsTable != null) {
+            if (stringsTable != null && !stringsTable.IsEmpty) {
                 currentStringsTable = stringsTable.GetTable();
             }
 
-            if (assetTable != null) {
+            if (assetTable != null && !assetTable.IsEmpty) {
                 currentAssetTable = assetTable.GetTable();
             }
 


### PR DESCRIPTION
* **What kind of change does this pull request introduce?**
- [x] Bug Fix

This fixes the bug report: #205 
I simply added a check for `IsEmpty` in `UnityLocalisedLineProvider.cs` to ensure the `stringsTable` and `assetTable` not only exist, but have a value selected in the editor.

Without these checks, the editor will throw an error if either value is set to "none".
You might be able to skip the null check for a very small performance gain, but I left it in to keep changes to a minimum.