### PR TITLE
Memoize GetElementHeight()

### DIFF
--- a/Editor/Importers/YarnProjectImporter.cs
+++ b/Editor/Importers/YarnProjectImporter.cs
@@ -840,6 +840,8 @@ namespace Yarn.Unity.Editor
         private SerializedObject serializedObject;
         private SerializedProperty serializedProperty;
 
+        private Dictionary<int, float> _lineHeights = new Dictionary<int, float>();
+
         public ReorderableDeclarationsList(SerializedObject serializedObject, SerializedProperty property)
         {
             this.serializedObject = serializedObject;
@@ -953,8 +955,12 @@ namespace Yarn.Unity.Editor
 
             if (useSearch == false || ShouldShowElement(index))
             {
-                var item = serializedProperty.GetArrayElementAtIndex(index);
-                return DeclarationPropertyDrawer.GetPropertyHeightImpl(item, null);
+                if (!_lineHeights.ContainsKey(index))
+                {
+                    var item = serializedProperty.GetArrayElementAtIndex(index);
+                    _lineHeights[index] = DeclarationPropertyDrawer.GetPropertyHeightImpl(item, null);
+                }
+                return _lineHeights[index];
             }
             else
             {
@@ -978,6 +984,7 @@ namespace Yarn.Unity.Editor
 
         public void DrawLayout()
         {
+            _lineHeights.Clear();
             //serializedObject.Update();
             EditorGUILayout.Space();
 


### PR DESCRIPTION
On a project with ~300 yarn variables, I am seeing GetElementHeight get called *thousands* of times per interaction with the Inspector panel.  Memoizing this call reduces repaint time from ~10 seconds down to 0.3 seconds on this project.

* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] Does it pass all existing unit tests without modification?
    - If not, what did you change?
    - If you altered it significantly, what coverage issue did you fix?
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [ ] Feature
- [x] Something else

* **What is the current behavior?**

On 2019.4.36f1, with a project with a decent number of variables, the editor hard hangs trying to render the Inspector panel while trying to interact with the .yarnproject file.

* **What is the new behavior (if this is a feature change)?**

Instead of hanging, the inspector repaints 2-3 times per second.

* **Does this pull request introduce a breaking change?**

No

* **Other information**:

Significant performance gain when viewing .yarnproject files with many variables (10-100x)
