### PR TITLE
LineView.UserRequestedViewAdvancement don't advance line if Animation was running

### DIFF
--- a/Runtime/Views/LineView.cs
+++ b/Runtime/Views/LineView.cs
@@ -655,9 +655,12 @@ namespace Yarn.Unity
                 // started it.
                 currentStopToken.Interrupt();
             }
-            // No animation is now running. Signal that we want to
-            // interrupt the line instead.
-            requestInterrupt?.Invoke();
+            else
+            {
+                // No animation is now running. Signal that we want to
+                // interrupt the line instead.
+                requestInterrupt?.Invoke();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Changed LineView.UserRequestedViewAdvancement to interrupt line only if no animation is running.

- [X] Passes all unit tests without modification with Unity 2021.3.11f
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~
- [ ] CHANGELOG.md has been updated to describe this change

<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->

<!-- To update the documentation on yarnspinner.dev, please submit a pull request to the documentation repository at https://github.com/YarnSpinnerTool/Docs. -->

# Change Type

- [X] Bug Fix

#  Behavior changes

Fixes #190 

The current behavior is that `LineView` both stops animations and interrupts the line at the same time. With the typewriter effect, for example, it immediately progresses to the next line without showing the full line, which is unexpected from the user perspective.

If this behavior is intentional (which I doubt, as it wasn't mentioned in #169 ), this should be at least be an optional feature.

<!--

Ideas:

- Performance?
  - Does this drastically change performance characteristics, or simply allow for optimizations?
  - Does this performance involve:
    - Disk access
    - CPU time
    - Memory layout optimization (Lx caching etc)
  - Might there be a use case where you are encouraged to be unperformant by default?
  - What optimizations did you consider but left out due to time and/or complexity?
- Usability?
  - If your change is to a sample, is it accessible? We don't follow standards like WCAG but any easy wins should be taken.
  - Does it make it easier to use our API? If not, what annoyance mitigations have you taken/considered?
- Who will be affected?
  - Is this an internal change, or something meant to be consumed by the end user?
  - If you add API changes, is it easily upgradable from the previous version?
  - What indirect consequence might be annoying to the end user?
    - For what reasons would you say this is justified? E.g. super annoying to use in the first place, tightening up undefined behavior etc.
- What do you think will be controversial, if any?
- How would you describe the cause of the problem and changes to non-technical users if at all possible?

Feel free to take any all or none of these points as relevant, though we recommend you read through each point. They're just to get you started!

-->
