### PR TITLE
Feature/allow restricted asset search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The Unity Localization integration is now available when the Localization package is installed.
   - Prior to this change, the `YARN_USE_EXPERIMENTAL_FEATURES` scripting definition symbol needed to be added to the Player settings.
+- Added `YarnEditorUtility.AssetSearchFolders` to allow defining custom Yarn asset folders via script.
+  - This can speed up the time to enter PlayMode significantly, because YarnSpinner no longer scans the entire project for Yarn Files.
 
 ### Changed
 

--- a/Editor/Utility/YarnEditorUtility.cs
+++ b/Editor/Utility/YarnEditorUtility.cs
@@ -12,14 +12,22 @@ namespace Yarn.Unity.Editor
     /// </summary>
     public static class YarnEditorUtility
     {
-
+        
         // GUID for editor assets. (Doing it like this means that we don't
         // have to worry about where the assets are on disk, if the user
         // has moved Yarn Spinner around.)
         const string DocumentIconTextureGUID = "0ed312066ea6f40f6af965f21c818b34";
         const string ProjectIconTextureGUID = "f6a533d9225cd40ea9ded31d4f686e3b";
         const string TemplateFileGUID = "4f4ca4a46020a454f80e2ac78eda5aa1";
-
+        
+        /// <summary>
+        /// By default, we search for Yarn files throughout the entire project.
+        /// However, as the project grows, this can get slow.
+        /// To address this issue, you can define a custom list of folders to search in.
+        /// Keep in mind that all Yarn files must be located within these folders or their subfolders to be detected.
+        /// </summary>
+        public static string[] AssetSearchFolders = null;
+        
         /// <summary>
         /// Returns a <see cref="Texture2D"/> that can be used to represent
         /// Yarn files.
@@ -223,7 +231,7 @@ namespace Yarn.Unity.Editor
         /// <param name="converter">Custom type caster.</param>
         /// <returns>Enumerable of all assets of a given type.</returns>
         public static IEnumerable<T> GetAllAssetsOf<T>(string filterQuery, System.Func<AssetImporter, T> converter = null) where T : class
-            => AssetDatabase.FindAssets(filterQuery)
+            => AssetDatabase.FindAssets(filterQuery, AssetSearchFolders)
                 .Select(AssetDatabase.GUIDToAssetPath)
                 .Select(AssetImporter.GetAtPath)
                 .Select(importer => converter?.Invoke(importer) ?? importer as T)


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] Does it pass all existing unit tests without modification?
    - If not, what did you change?
    - If you altered it significantly, what coverage issue did you fix?
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->

<!-- To update the documentation on yarnspinner.dev, please submit a pull request to the documentation repository at https://github.com/YarnSpinnerTool/Docs. -->

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [ ] Feature
- [x] Something else

* **What is the current behavior?**

Like described in https://github.com/YarnSpinnerTool/YarnSpinner-Unity/issues/188 currently the Plugin scans ALL files in the project for Yarn files when starting PlayMode. This also includes all installed Plugins and Packages. With a growing project this takes more and more time, for me personally it's at 2sec every PlayMode start now.

* **What is the new behavior (if this is a feature change)?**

`FindAssets(string filter)` calls `FindAssets(filter, (string[]) null)` internally, so per default nothing will change. However you now have the ability to define your own Asset-Location via a Editor Script. It could look like this for example:
```[InitializeOnLoad]
    internal static class EditorSetYarnSearchFolders
    {
        static EditorSetYarnSearchFolders()
        {
            YarnEditorUtility.AssetSearchFolders = new[]
            {
                "Assets/YarnSpinner"
            };
        }
    }
```

A nicer solution would be to make this configurable, but I think currently the YarnSpinner-Plugin does not have its own configuration system and I didn't want to introduce one for this workaround. Optimally some kind of cache would be implemented that remembers all of the found Yarn files, so we could search the whole project once on startup or something like that. However this small change already helps to alleviate the pain for now.

* **Does this pull request introduce a breaking change?**

No, the default behavior stays exactly the same.

