### PR TITLE
Deactivate option views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - This does have the potential issue of long load times for some larger nodes, in those cases we suggest you preload more lines using `GetLineIDsForNodes` on `YarnProject`
 - `UnityLocalisedLineProvider` can now have it's default setting of removing unused assets disabled, this is useful when caching multiple nodes worth of assets
 - Add Assets to Asset Table Collection Wizard now correctly prepends `line:` to the key to match the documented behaviour.
+- `OptionsListView` now deactivates child options when they are not needed instead of just making them transparent.
 
 ### Removed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,3 +16,4 @@ The following people have contributed to the development of Yarn Spinner. If you
 * 2023: ChocolaMint (https://chocola-mint.github.io/)
 * 2023: Mitch Zais <https://github.com/Invertex>
 * 2023: Thomas Ingram (https://vertx.xyz)
+* 2023: Isaac Berman (https://github.com/bermanisaac)

--- a/Runtime/Views/OptionsListView.cs
+++ b/Runtime/Views/OptionsListView.cs
@@ -54,12 +54,6 @@ namespace Yarn.Unity
 
         public override void RunOptions(DialogueOption[] dialogueOptions, Action<int> onOptionSelected)
         {
-            // Hide all existing option views
-            foreach (var optionView in optionViews)
-            {
-                optionView.gameObject.SetActive(false);
-            }
-
             // If we don't already have enough option views, create more
             while (dialogueOptions.Length > optionViews.Count)
             {
@@ -136,7 +130,7 @@ namespace Yarn.Unity
 
                 IEnumerator OptionViewWasSelectedInternal(DialogueOption selectedOption)
                 {
-                    yield return StartCoroutine(Effects.FadeAlpha(canvasGroup, 1, 0, fadeTime));
+                    yield return StartCoroutine(FadeAndDisableOptionViews(canvasGroup, 1, 0, fadeTime));
                     OnOptionSelected(selectedOption.DialogueOptionID);
                 }
             }
@@ -157,7 +151,21 @@ namespace Yarn.Unity
                 canvasGroup.interactable = false;
                 canvasGroup.blocksRaycasts = false;
 
-                StartCoroutine(Effects.FadeAlpha(canvasGroup, canvasGroup.alpha, 0, fadeTime));
+                StartCoroutine(FadeAndDisableOptionViews(canvasGroup, canvasGroup.alpha, 0, fadeTime));
+            }
+        }
+
+        /// <summary>
+        /// Fades canvas and then disables all option views.
+        /// </summary>
+        private IEnumerator FadeAndDisableOptionViews(CanvasGroup canvasGroup, float from, float to, float fadeTime)
+        {
+            yield return Effects.FadeAlpha(canvasGroup, from, to, fadeTime);
+
+            // Hide all existing option views
+            foreach (var optionView in optionViews)
+            {
+                optionView.gameObject.SetActive(false);
             }
         }
     }


### PR DESCRIPTION
When an option is selected in OptionsListView, disable all child OptionView GameObjects after fading the canvas alpha to 0. This is to avoid unintended effects of leaving the options active when the dialogue view itself is not active, such as animations, audio sources, or other scripts on a custom OptionView.

No longer disable all OptionView objects when initializing options in OptionsListView.RunOptions, as any existing ones will have been disabled at the end of the previous options interaction. New OptionView objects created are still disabled before their use.

See brief discussion on Discord: https://discord.com/channels/754171172693868585/1072667932078903400/1154638863877287936

* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [X] Does it pass all existing unit tests without modification?
    - If not, what did you change?
    - If you altered it significantly, what coverage issue did you fix?
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~
- [ ] CHANGELOG.md has been updated to describe this change

<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->

<!-- To update the documentation on yarnspinner.dev, please submit a pull request to the documentation repository at https://github.com/YarnSpinnerTool/Docs. -->

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [ ] Feature
- [X] Something else

* **What is the current behavior?**

<!-- If you are fixing a known bug, you can also link to an open issue here. -->
When an option is selected under an `OptionsListView`, the child `OptionView` objects are left enabled and only the canvas group is made transparent, hiding all options. This can lead to unintended behavior if a custom `OptionView` script or Prefab is used, as animations or sounds may continue playing, scripts will continue to Update, etc. 

* **What is the new behavior (if this is a feature change)?**

<!-- Please describe, in as much detail as you can, what your pull request changes in Yarn Spinner. -->
All child `OptionView` objects are disabled either when an option is selected, or when `OptionsListView.DialogueCompleted()` is called. The canvas is faded before options are disabled, so there is no visible change in behavior.

Additionally, previously created `OptionView` objects are no longer disabled when presenting a new set of options since they will already have been disabled.

* **Does this pull request introduce a breaking change?**

<!-- What changes might users need to make in their application due to this PR? -->
No. If this functionality was desired, it would almost certainly be in the context of other custom views, and writing a custom options view to restore previous behavior would be simple.
* **Other information**:

<!--

Ideas:

- Performance?
  - Does this drastically change performance characteristics, or simply allow for optimizations?
  - Does this performance involve:
    - Disk access
    - CPU time
    - Memory layout optimization (Lx caching etc)
  - Might there be a use case where you are encouraged to be unperformant by default?
  - What optimizations did you consider but left out due to time and/or complexity?
- Usability?
  - If your change is to a sample, is it accessible? We don't follow standards like WCAG but any easy wins should be taken.
  - Does it make it easier to use our API? If not, what annoyance mitigations have you taken/considered?
- Who will be affected?
  - Is this an internal change, or something meant to be consumed by the end user?
  - If you add API changes, is it easily upgradable from the previous version?
  - What indirect consequence might be annoying to the end user?
    - For what reasons would you say this is justified? E.g. super annoying to use in the first place, tightening up undefined behavior etc.
- What do you think will be controversial, if any?
- How would you describe the cause of the problem and changes to non-technical users if at all possible?

Feel free to take any all or none of these points as relevant, though we recommend you read through each point. They're just to get you started!

--> Although the change is minor, it removes the unintuitive behavior that when the options view is not active, its children remain enabled. They have to be disabled before displaying a new set of options in any case, so the work is done in advance for clarity.
