### PR TITLE
DialogueRunner: add option to silence empty view warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `Yarn.Unity.ActionAnalyser.Action` now has a `MethodIdentifierName` property, which is the short form of the method name.
 - `LineView` now will add in line breaks when it encounters a self closing `[br /]` marker.
 - Yarn attributed Functions and Commands can now use constant values in addition to literals for their name.
+- `DialogueRunner` now has a `silenceDialogueViewWarning` property. When set to true, the dialogue runner will no longer print a warning if the `dialogueViews` array is empty. 
 
 ### Changed
 

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -96,6 +96,14 @@ namespace Yarn.Unity
         /// </summary>
         public bool runSelectedOptionAsLine;
 
+        /// <summary>
+        /// By default, DialogueRunner will print a warning if no DialogueViews
+        /// are assigned to <see cref="dialogueViews"/>. However, if you
+        /// assign the views at runtime, this warning isn't useful. Set this to
+        /// true to silence the warning.
+        /// </summary>
+        public bool silenceDialogueViewWarning;
+
         public LineProviderBehaviour lineProvider;
 
         /// <summary>
@@ -653,7 +661,7 @@ namespace Yarn.Unity
         void Awake()
         {
             
-            if (dialogueViews.Length == 0)
+            if (dialogueViews.Length == 0 && !silenceDialogueViewWarning)
             {
                 Debug.LogWarning($"Dialogue Runner doesn't have any dialogue views set up. No lines or options will be visible.");
             }


### PR DESCRIPTION
* **Tests**

- [ ] Tests for the changes have been added (for bug fixes / features) - **n/a**
  - [x] Does it pass all existing unit tests without modification?
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?**

When `DialogueRunner.Awake()` executes, it prints a warning if `dialogueViews` is empty.

* **What is the new behavior (if this is a feature change)?**

You can toggle a boolean property called `silenceDialogueViewWarning`, which does what it says on the tin. When set, the warning will not be printed.

I'm writing a project where the view is set at runtime, so the warning produces unhelpful noise each time I run the project.

* **Does this pull request introduce a breaking change?**

No, the default is to continue the old behavior.

* **Other information**:

This change is a small quality-of-life improvement, and hopefully unobtrusive for folks who don't need it!