### PR TITLE
Change reference table in LineProvider at runtime

### DIFF
--- a/Runtime/LineProviders/UnityLocalisedLineProvider.cs
+++ b/Runtime/LineProviders/UnityLocalisedLineProvider.cs
@@ -150,7 +150,7 @@ namespace Yarn.Unity.UnityLocalization
         public void SetTable(LocalizedStringTable stringsTable, LocalizedAssetTable assetTable)
         {
             // doing an initial load of the strings
-            if (stringsTable != null)
+            if (stringsTable != null && this.stringsTable != stringsTable)
             {
                 this.stringsTable = stringsTable;
 
@@ -161,7 +161,7 @@ namespace Yarn.Unity.UnityLocalization
                 stringsTable.TableChanged += OnStringTableChanged;
             }
 
-            if (assetTable != null)
+            if (assetTable != null && this.assetTable != assetTable)
             {
                 this.assetTable = assetTable;
 

--- a/Runtime/LineProviders/UnityLocalisedLineProvider.cs
+++ b/Runtime/LineProviders/UnityLocalisedLineProvider.cs
@@ -120,24 +120,7 @@ namespace Yarn.Unity.UnityLocalization
             return localizedLine;
         }
 
-        public override void Start()
-        {
-            // doing an initial load of the strings
-            if (stringsTable != null)
-            {
-                // Adding an event handler to TableChanged will trigger an
-                // initial async load of the string table, which will call the
-                // handler on completion. So, we don't set currentStringsTable
-                // here, but instead we only ever do it in OnStringTableChanged.
-                stringsTable.TableChanged += OnStringTableChanged;
-            }
-
-            if (assetTable != null)
-            {
-                // Same logic for asset table as for strings table, above.
-                assetTable.TableChanged += OnAssetTableChanged;
-            }
-        }
+        public override void Start() => SetTable(stringsTable, assetTable);
 
         // We've been notified that a new strings table has been loaded.
         private void OnStringTableChanged(StringTable newTable)
@@ -149,6 +132,42 @@ namespace Yarn.Unity.UnityLocalization
         private void OnAssetTableChanged(AssetTable value)
         {
             currentAssetTable = value;
+        }
+
+        /// <summary>
+        /// Updates referenced LocalizedStringTable.
+        /// </summary>
+        public void SetTable(LocalizedStringTable stringsTable) => SetTable(stringsTable, assetTable);
+        
+        /// <summary>
+        /// Updates referenced LocalizedAssetTable.
+        /// </summary>
+        public void SetTable(LocalizedAssetTable assetTable) => SetTable(stringsTable, assetTable);
+
+        /// <summary>
+        /// Updates both referenced LocalizedStringTable and LocalizedAssetTable.
+        /// </summary>
+        public void SetTable(LocalizedStringTable stringsTable, LocalizedAssetTable assetTable)
+        {
+            // doing an initial load of the strings
+            if (stringsTable != null)
+            {
+                this.stringsTable = stringsTable;
+
+                // Adding an event handler to TableChanged will trigger an
+                // initial async load of the string table, which will call the
+                // handler on completion. So, we don't set currentStringsTable
+                // here, but instead we only ever do it in OnStringTableChanged.
+                stringsTable.TableChanged += OnStringTableChanged;
+            }
+
+            if (assetTable != null)
+            {
+                this.assetTable = assetTable;
+
+                // Same logic for asset table as for strings table, above.
+                assetTable.TableChanged += OnAssetTableChanged;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [x] Does it pass all existing unit tests without modification?
    - If not, what did you change?
    - If you altered it significantly, what coverage issue did you fix?
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->

<!-- To update the documentation on yarnspinner.dev, please submit a pull request to the documentation repository at https://github.com/YarnSpinnerTool/Docs. -->

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?**

Right now you have to set the table before UnityLocalisedLineProvider.cs Starts.

* **What is the new behavior (if this is a feature change)?**

You can now set the table at runtime.

* **Does this pull request introduce a breaking change?**

No.