### PR TITLE
Added onOptionSelected event to DialogueRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added onOptionSelected event to DialogueRunner which is raised once a dialogue view selected an option.
+
 ### Changed
 
 - Fixed an issue where, on Windows, projects would fail to automatically update when a file that belonged to them was created or edited.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,3 +17,4 @@ The following people have contributed to the development of Yarn Spinner. If you
 * 2023: Mitch Zais <https://github.com/Invertex>
 * 2023: Thomas Ingram (https://vertx.xyz)
 * 2023: Isaac Berman (https://github.com/bermanisaac)
+* 2023: Josh Guerrero (https://github.com/joshgrrro)

--- a/Editor/Editors/DialogueRunnerEditor.cs
+++ b/Editor/Editors/DialogueRunnerEditor.cs
@@ -33,6 +33,7 @@ namespace Yarn.Unity.Editor
         private SerializedProperty onDialogueStartProperty;
         private SerializedProperty onDialogueCompleteProperty;
         private SerializedProperty onCommandProperty;
+        private SerializedProperty onOptionSelectedProperty;
 
         private void OnEnable()
         {
@@ -49,6 +50,7 @@ namespace Yarn.Unity.Editor
             onDialogueStartProperty = serializedObject.FindProperty(nameof(DialogueRunner.onDialogueStart));
             onDialogueCompleteProperty = serializedObject.FindProperty(nameof(DialogueRunner.onDialogueComplete));
             onCommandProperty = serializedObject.FindProperty(nameof(DialogueRunner.onCommand));
+            onOptionSelectedProperty = serializedObject.FindProperty(nameof(DialogueRunner.onOptionSelected));
         }
 
         public override void OnInspectorGUI()
@@ -136,6 +138,7 @@ namespace Yarn.Unity.Editor
                 EditorGUILayout.PropertyField(onDialogueStartProperty);
                 EditorGUILayout.PropertyField(onDialogueCompleteProperty);
                 EditorGUILayout.PropertyField(onCommandProperty);
+                EditorGUILayout.PropertyField(onOptionSelectedProperty);
             }
 
             EditorGUILayout.EndFoldoutHeaderGroup();

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -1039,12 +1039,12 @@ namespace Yarn.Unity
                 throw new InvalidOperationException("Selecting an option on the same frame that options are provided is not allowed. Wait at least one frame before selecting an option.");
             }
             
+            // Notify listeners that an option was selected
+            onOptionSelected.Invoke(optionIndex);
+
             // Mark that this is the currently selected option in the
             // Dialogue
             Dialogue.SetSelectedOption(optionIndex);
-
-            // Notify listeners that an option was selected
-            onOptionSelected.Invoke(optionIndex);
 
             if (runSelectedOptionAsLine)
             {

--- a/Runtime/DialogueRunner.cs
+++ b/Runtime/DialogueRunner.cs
@@ -101,6 +101,17 @@ namespace Yarn.Unity
         public class StringUnityEvent : UnityEvent<string> { }
 
         /// <summary>
+        /// A type of <see cref="UnityEvent"/> that takes a single integer
+        /// parameter.
+        /// </summary>
+        /// <remarks>
+        /// A concrete subclass of <see cref="UnityEvent"/> is needed in
+        /// order for Unity to serialise the type correctly.
+        /// </remarks>
+        [Serializable]
+        public class IntUnityEvent : UnityEvent<int> { }
+
+        /// <summary>
         /// A Unity event that is called when a node starts running.
         /// </summary>
         /// <remarks>
@@ -159,6 +170,15 @@ namespace Yarn.Unity
         /// <seealso cref="AddCommandHandler(string, CommandHandler)"/>
         /// <seealso cref="YarnCommandAttribute"/>
         public StringUnityEvent onCommand;
+
+        /// <summary>
+        /// A <see cref="IntUnityEvent"/> that is called when an option is selected.
+        /// </summary>
+        /// <remarks>
+        /// This event receives as a parameter the index of the option that
+        /// was selected.
+        /// </remarks>
+        public IntUnityEvent onOptionSelected;
 
         /// <summary>
         /// Gets the name of the current node that is being run.
@@ -1022,6 +1042,9 @@ namespace Yarn.Unity
             // Mark that this is the currently selected option in the
             // Dialogue
             Dialogue.SetSelectedOption(optionIndex);
+
+            // Notify listeners that an option was selected
+            onOptionSelected.Invoke(optionIndex);
 
             if (runSelectedOptionAsLine)
             {


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] Does it pass all existing unit tests without modification?
    - If not, what did you change?
    - If you altered it significantly, what coverage issue did you fix?
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->

<!-- To update the documentation on yarnspinner.dev, please submit a pull request to the documentation repository at https://github.com/YarnSpinnerTool/Docs. -->

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?**

    No event is raised when an option is selected by a Dialogue View.

<!-- If you are fixing a known bug, you can also link to an open issue here. -->

* **What is the new behavior (if this is a feature change)?**

    An new event is raised by the Dialogue Runner when an option is selected.

<!-- Please describe, in as much detail as you can, what your pull request changes in Yarn Spinner. -->

* **Does this pull request introduce a breaking change?**

    No breaking changes.

<!-- What changes might users need to make in their application due to this PR? -->

* **Other information**:

    Adding the onOptionSelected event allows multiple components to react to a selected option without coupling them to the Dialogue View responsible for the selection. Specifically, this allows multiple Dialogue Views to handle the RunOptions method without being coupled to one another-- they can be notified if another Dialogue View selects an option and take action accordingly.

    Important notes:
    - The event is raised before the call to Dialogue.SetSelectedOption, which may need some consideration. The thought was that subscribers would want to handle their own cases before the state of the Yarn program was updated in any way.
    - The event only sends the index of the option. If a subscriber needs more information about the option itself, it must obtain it some other way (such as implementing RunOptions, if the subscriber is a Dialogue View).

    Link to documentation pull request: [https://github.com/YarnSpinnerTool/YSDocs/pull/58](https://github.com/YarnSpinnerTool/YSDocs/pull/58)

<!--

Ideas:

- Performance?
  - Does this drastically change performance characteristics, or simply allow for optimizations?
  - Does this performance involve:
    - Disk access
    - CPU time
    - Memory layout optimization (Lx caching etc)
  - Might there be a use case where you are encouraged to be unperformant by default?
  - What optimizations did you consider but left out due to time and/or complexity?
- Usability?
  - If your change is to a sample, is it accessible? We don't follow standards like WCAG but any easy wins should be taken.
  - Does it make it easier to use our API? If not, what annoyance mitigations have you taken/considered?
- Who will be affected?
  - Is this an internal change, or something meant to be consumed by the end user?
  - If you add API changes, is it easily upgradable from the previous version?
  - What indirect consequence might be annoying to the end user?
    - For what reasons would you say this is justified? E.g. super annoying to use in the first place, tightening up undefined behavior etc.
- What do you think will be controversial, if any?
- How would you describe the cause of the problem and changes to non-technical users if at all possible?

Feel free to take any all or none of these points as relevant, though we recommend you read through each point. They're just to get you started!

-->
