### PR TITLE
Fix merge conflict in TestCommands.cs.meta

### DIFF
--- a/Tests/Runtime/CommandDispatchTests/AssemblyDefinition/TestCommands.cs.meta
+++ b/Tests/Runtime/CommandDispatchTests/AssemblyDefinition/TestCommands.cs.meta
@@ -1,9 +1,5 @@
 fileFormatVersion: 2
-<<<<<<< HEAD:Tests/Runtime/AssemblyDefinition/TestCommands.cs.meta
 guid: 36d12434272144830aed6106488edee7
-=======
-guid: ca28301cfbfea4c83bae10ed899b6c3c
->>>>>>> a066b5d070402f58ae17de3338d995203e890fcf:Runtime/Views/ViewInputAddon.cs.meta
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
Fixes #284. Leaving barebones incase someone wants to just cherry-pick the commit, or make the change, and put it in a more meaningful PR. Ultimately just wanted to re-raise awareness since the issue hasn't been dealt with and Unity 6 is honking a ton because of it.