### PR TITLE
Fix late line complete callback in line with markup

### DIFF
--- a/Runtime/Views/LinePresenter.cs
+++ b/Runtime/Views/LinePresenter.cs
@@ -343,9 +343,12 @@ namespace Yarn.Unity
                 {
                     milliSecondsPerLetter = (int)(1000f / typewriterEffectSpeed);
                 }
-
+                
+                // Get the count of visible characters from TextMesh to exclude markup characters
+                var visibleCharacterCount = lineText.GetTextInfo(text.Text).characterCount;
+                
                 // going through each character of the line and letting the processors know about it
-                for (int i = 0; i < text.Text.Length; i++)
+                for (int i = 0; i < visibleCharacterCount; i++)
                 {
                     // telling every processor that it is time to process the current character
                     foreach (var processor in temporalProcessors)
@@ -360,7 +363,7 @@ namespace Yarn.Unity
                     }
                 }
 
-                lineText.maxVisibleCharacters = text.Text.Length;
+                lineText.maxVisibleCharacters = visibleCharacterCount;
 
                 // letting each temporal processor know the line has finished displaying
                 foreach (var processor in temporalProcessors)


### PR DESCRIPTION
Fixes https://github.com/YarnSpinnerTool/YarnSpinner-Unity/issues/328

When showing characters with the typewriter effect the `LinePresenter` loops the characters in the string and sets maxVisibleCharacters on the Textmesh component. If a line has markup tags those will be looped too. That means when a line contains markup it will exceed the number of characters that needs to be passed to TM causing a delay between the text becoming visible at runtime and the `OnLineDisplayComplete()` method being called.

This can cause issues if, for example, a connected `ActionMarkupHandler` needs to decide whether call `RequestHurryUpLine()` or `RequestNextLine()` as the line will be visibly finished, but the loop will still be running for the count of extra characters.

This replaces the total count in the loop with the amount of visible characters so it will sync back up.

For some reason `lineText.textInfo` doesn't contain the correct current count but calling `lineText.GetTextInfo()` with the current line text does.