### PR TITLE
Fixed a bug where the Continue Button would sometimes become unclickable after the first dialogue line appears when Start Automatically is set to true

### DIFF
--- a/Runtime/Views/LinePresenterButtonHandler.cs
+++ b/Runtime/Views/LinePresenterButtonHandler.cs
@@ -25,7 +25,7 @@ namespace Yarn.Unity
         [MustNotBeNullWhen(nameof(continueButton), "A " + nameof(DialogueRunner) + " must be provided for the continue button to work.")]
         [SerializeField] DialogueRunner? dialogueRunner;
 
-        void Start()
+        void Awake()
         {
             if (continueButton == null)
             {


### PR DESCRIPTION
Fixed a bug where the Continue Button would sometimes become unclickable after the first dialogue line appears when Start Automatically is set to true.

Root cause: In Unity, the execution order of Start() functions across different components is unpredictable. If LinePresenterButtonHandler's Start() is called after DialogueRunner's Start(), it can lead to a situation where LinePresenterButtonHandler's OnPrepareForLine() is invoked
 before LinePresenterButtonHandler's Start(). This causes the Continue Button to be reset to interactable = false and enabled = false.